### PR TITLE
Fix payer proof selective disclosure follow-ups

### DIFF
--- a/lightning/src/ln/offers_tests.rs
+++ b/lightning/src/ln/offers_tests.rs
@@ -61,6 +61,8 @@ use crate::offers::invoice_error::InvoiceError;
 use crate::offers::invoice_request::{InvoiceRequest, InvoiceRequestFields, InvoiceRequestVerifiedFromOffer};
 use crate::offers::nonce::Nonce;
 use crate::offers::parse::Bolt12SemanticError;
+use crate::offers::payer_proof::{PayerProof, PayerProofError};
+use crate::types::payment::PaymentPreimage;
 use crate::onion_message::messenger::{DefaultMessageRouter, Destination, MessageSendInstructions, NodeIdMessageRouter, NullMessageRouter, PeeledOnion, DUMMY_HOPS_PATH_LENGTH, QR_CODED_DUMMY_HOPS_PATH_LENGTH};
 use crate::onion_message::offers::OffersMessage;
 use crate::routing::gossip::{NodeAlias, NodeId};
@@ -258,6 +260,21 @@ fn extract_offer_nonce<'a, 'b, 'c>(node: &Node<'a, 'b, 'c>, message: &OnionMessa
 	match node.onion_messenger.peel_onion_message(message) {
 		Ok(PeeledOnion::Offers(_, Some(OffersContext::InvoiceRequest { nonce }), _)) => nonce,
 		Ok(PeeledOnion::Offers(_, context, _)) => panic!("Unexpected onion message context: {:?}", context),
+		Ok(PeeledOnion::Forward(_, _)) => panic!("Unexpected onion message forward"),
+		Ok(_) => panic!("Unexpected onion message"),
+		Err(e) => panic!("Failed to process onion message {:?}", e),
+	}
+}
+
+/// Extract the payer's nonce from an invoice onion message received by the payer.
+///
+/// When the payer receives an invoice through their reply path, the blinded path context
+/// contains the nonce originally used for deriving their payer signing key. This nonce is
+/// needed to build a [`PayerProof`] using [`PayerProofBuilder::build_with_derived_key`].
+fn extract_payer_context<'a, 'b, 'c>(node: &Node<'a, 'b, 'c>, message: &OnionMessage) -> (PaymentId, Nonce) {
+	match node.onion_messenger.peel_onion_message(message) {
+		Ok(PeeledOnion::Offers(_, Some(OffersContext::OutboundPaymentForOffer { payment_id, nonce, .. }), _)) => (payment_id, nonce),
+		Ok(PeeledOnion::Offers(_, context, _)) => panic!("Expected OutboundPaymentForOffer context, got: {:?}", context),
 		Ok(PeeledOnion::Forward(_, _)) => panic!("Unexpected onion message forward"),
 		Ok(_) => panic!("Unexpected onion message"),
 		Err(e) => panic!("Failed to process onion message {:?}", e),
@@ -2666,4 +2683,228 @@ fn creates_and_pays_for_phantom_offer() {
 		assert!(nodes[0].onion_messenger.next_onion_message_for_peer(node_b_id).is_none());
 		assert!(nodes[0].onion_messenger.next_onion_message_for_peer(node_c_id).is_none());
 	}
+}
+
+/// Tests the full payer proof lifecycle: offer -> invoice_request -> invoice -> payment ->
+/// proof creation with derived key signing -> verification -> bech32 round-trip.
+///
+/// This exercises the primary API path where a wallet pays a BOLT 12 offer and then creates
+/// a payer proof using the derived signing key (same key derivation as the invoice request).
+#[test]
+fn creates_and_verifies_payer_proof_after_offer_payment() {
+	let chanmon_cfgs = create_chanmon_cfgs(2);
+	let node_cfgs = create_node_cfgs(2, &chanmon_cfgs);
+	let node_chanmgrs = create_node_chanmgrs(2, &node_cfgs, &[None, None]);
+	let nodes = create_network(2, &node_cfgs, &node_chanmgrs);
+
+	create_announced_chan_between_nodes_with_value(&nodes, 0, 1, 10_000_000, 1_000_000_000);
+
+	let alice = &nodes[0]; // recipient (offer creator)
+	let alice_id = alice.node.get_our_node_id();
+	let bob = &nodes[1]; // payer
+	let bob_id = bob.node.get_our_node_id();
+
+	// Alice creates an offer
+	let offer = alice.node
+		.create_offer_builder().unwrap()
+		.amount_msats(10_000_000)
+		.build().unwrap();
+
+	// Bob initiates payment
+	let payment_id = PaymentId([1; 32]);
+	bob.node.pay_for_offer(&offer, None, payment_id, Default::default()).unwrap();
+	expect_recent_payment!(bob, RecentPaymentDetails::AwaitingInvoice, payment_id);
+
+	// Bob sends invoice request to Alice
+	let onion_message = bob.onion_messenger.next_onion_message_for_peer(alice_id).unwrap();
+	alice.onion_messenger.handle_onion_message(bob_id, &onion_message);
+
+	let (invoice_request, _) = extract_invoice_request(alice, &onion_message);
+
+	// Alice sends invoice back to Bob
+	let onion_message = alice.onion_messenger.next_onion_message_for_peer(bob_id).unwrap();
+	bob.onion_messenger.handle_onion_message(alice_id, &onion_message);
+
+	let (invoice, _) = extract_invoice(bob, &onion_message);
+	assert_eq!(invoice.amount_msats(), 10_000_000);
+
+	// Extract the payer nonce and payment_id from Bob's reply path context. In a real wallet,
+	// these would be persisted alongside the payment for later payer proof creation.
+	let (context_payment_id, payer_nonce) = extract_payer_context(bob, &onion_message);
+	assert_eq!(context_payment_id, payment_id);
+
+	// Route the payment
+	route_bolt12_payment(bob, &[alice], &invoice);
+	expect_recent_payment!(bob, RecentPaymentDetails::Pending, payment_id);
+
+	// Get the payment preimage from Alice's PaymentClaimable event and claim it.
+	// In a real wallet, the payer receives the preimage via Event::PaymentSent after the
+	// recipient claims. For the test, we extract it from the recipient's claimable event.
+	let payment_preimage = match get_event!(alice, Event::PaymentClaimable) {
+		Event::PaymentClaimable { purpose, .. } => {
+			match &purpose {
+				PaymentPurpose::Bolt12OfferPayment { payment_context, .. } => {
+					assert_eq!(payment_context.offer_id, offer.id());
+					assert_eq!(
+						payment_context.invoice_request.payer_signing_pubkey,
+						invoice_request.payer_signing_pubkey(),
+					);
+				},
+				_ => panic!("Expected Bolt12OfferPayment purpose"),
+			}
+			purpose.preimage().unwrap()
+		},
+		_ => panic!("Expected Event::PaymentClaimable"),
+	};
+
+	claim_payment(bob, &[alice], payment_preimage);
+	expect_recent_payment!(bob, RecentPaymentDetails::Fulfilled, payment_id);
+
+	// --- Payer Proof Creation ---
+	// Bob (the payer) creates a proof-of-payment with selective disclosure.
+	// He includes the offer description and invoice amount, but omits other fields for privacy.
+	let expanded_key = bob.keys_manager.get_expanded_key();
+	let proof = invoice.payer_proof_builder(payment_preimage).unwrap()
+		.include_offer_description()
+		.include_invoice_amount()
+		.include_invoice_created_at()
+		.build_with_derived_key(&expanded_key, payer_nonce, payment_id, None)
+		.unwrap();
+
+	// Check proof contents match the original payment
+	assert_eq!(proof.preimage(), payment_preimage);
+	assert_eq!(proof.payment_hash(), invoice.payment_hash());
+	assert_eq!(proof.payer_id(), invoice.payer_signing_pubkey());
+	assert_eq!(proof.issuer_signing_pubkey(), invoice.signing_pubkey());
+	assert!(proof.payer_note().is_none());
+
+	// --- Serialization Round-Trip ---
+	// The proof can be serialized to a bech32 string (lnp...) for sharing.
+	let encoded = proof.to_string();
+	assert!(encoded.starts_with("lnp1"));
+
+	// Round-trip through TLV bytes: re-parse the raw bytes (verification happens at parse time).
+	let decoded = PayerProof::try_from(proof.bytes().to_vec()).unwrap();
+	assert_eq!(decoded.preimage(), proof.preimage());
+	assert_eq!(decoded.payment_hash(), proof.payment_hash());
+	assert_eq!(decoded.payer_id(), proof.payer_id());
+	assert_eq!(decoded.issuer_signing_pubkey(), proof.issuer_signing_pubkey());
+	assert_eq!(decoded.merkle_root(), proof.merkle_root());
+}
+
+/// Tests payer proof creation with a payer note, selective disclosure of specific invoice
+/// fields, and error cases. Verifies that:
+/// - A wrong preimage is rejected
+/// - A minimal proof (required fields only) works
+/// - Selective disclosure with a payer note works
+/// - The proof survives a bech32 round-trip with the note intact
+#[test]
+fn creates_payer_proof_with_note_and_selective_disclosure() {
+	let chanmon_cfgs = create_chanmon_cfgs(2);
+	let node_cfgs = create_node_cfgs(2, &chanmon_cfgs);
+	let node_chanmgrs = create_node_chanmgrs(2, &node_cfgs, &[None, None]);
+	let nodes = create_network(2, &node_cfgs, &node_chanmgrs);
+
+	create_announced_chan_between_nodes_with_value(&nodes, 0, 1, 10_000_000, 1_000_000_000);
+
+	let alice = &nodes[0];
+	let alice_id = alice.node.get_our_node_id();
+	let bob = &nodes[1];
+	let bob_id = bob.node.get_our_node_id();
+
+	// Alice creates an offer with a description
+	let offer = alice.node
+		.create_offer_builder().unwrap()
+		.amount_msats(5_000_000)
+		.description("Coffee beans - 1kg".into())
+		.build().unwrap();
+
+	// Bob pays for the offer
+	let payment_id = PaymentId([2; 32]);
+	bob.node.pay_for_offer(&offer, None, payment_id, Default::default()).unwrap();
+	expect_recent_payment!(bob, RecentPaymentDetails::AwaitingInvoice, payment_id);
+
+	// Exchange messages
+	let onion_message = bob.onion_messenger.next_onion_message_for_peer(alice_id).unwrap();
+	alice.onion_messenger.handle_onion_message(bob_id, &onion_message);
+	let (invoice_request, _) = extract_invoice_request(alice, &onion_message);
+
+	let onion_message = alice.onion_messenger.next_onion_message_for_peer(bob_id).unwrap();
+	bob.onion_messenger.handle_onion_message(alice_id, &onion_message);
+
+	let (invoice, _) = extract_invoice(bob, &onion_message);
+	let (context_payment_id, payer_nonce) = extract_payer_context(bob, &onion_message);
+	assert_eq!(context_payment_id, payment_id);
+
+	// Route and claim the payment, extracting the preimage
+	route_bolt12_payment(bob, &[alice], &invoice);
+	expect_recent_payment!(bob, RecentPaymentDetails::Pending, payment_id);
+
+	let payment_preimage = match get_event!(alice, Event::PaymentClaimable) {
+		Event::PaymentClaimable { purpose, .. } => {
+			match &purpose {
+				PaymentPurpose::Bolt12OfferPayment { payment_context, .. } => {
+					assert_eq!(payment_context.offer_id, offer.id());
+					assert_eq!(
+						payment_context.invoice_request.payer_signing_pubkey,
+						invoice_request.payer_signing_pubkey(),
+					);
+				},
+				_ => panic!("Expected Bolt12OfferPayment purpose"),
+			}
+			purpose.preimage().unwrap()
+		},
+		_ => panic!("Expected Event::PaymentClaimable"),
+	};
+
+	claim_payment(bob, &[alice], payment_preimage);
+	expect_recent_payment!(bob, RecentPaymentDetails::Fulfilled, payment_id);
+
+	// --- Test 1: Wrong preimage is rejected ---
+	let wrong_preimage = PaymentPreimage([0xDE; 32]);
+	assert!(invoice.payer_proof_builder(wrong_preimage).is_err());
+
+	// --- Test 2: Wrong payment_id causes key derivation failure ---
+	let expanded_key = bob.keys_manager.get_expanded_key();
+	let wrong_payment_id = PaymentId([0xFF; 32]);
+	let result = invoice.payer_proof_builder(payment_preimage).unwrap()
+		.build_with_derived_key(&expanded_key, payer_nonce, wrong_payment_id, None);
+	assert!(matches!(result, Err(PayerProofError::KeyDerivationFailed)));
+
+	// --- Test 3: Wrong nonce causes key derivation failure ---
+	let wrong_nonce = Nonce::from_entropy_source(&chanmon_cfgs[0].keys_manager);
+	let result = invoice.payer_proof_builder(payment_preimage).unwrap()
+		.build_with_derived_key(&expanded_key, wrong_nonce, payment_id, None);
+	assert!(matches!(result, Err(PayerProofError::KeyDerivationFailed)));
+
+	// --- Test 4: Minimal proof (only required fields) ---
+	let minimal_proof = invoice.payer_proof_builder(payment_preimage).unwrap()
+		.build_with_derived_key(&expanded_key, payer_nonce, payment_id, None)
+		.unwrap();
+	// --- Test 5: Proof with selective disclosure and payer note ---
+	let proof_with_note = invoice.payer_proof_builder(payment_preimage).unwrap()
+		.include_offer_description()
+		.include_offer_issuer()
+		.include_invoice_amount()
+		.include_invoice_created_at()
+		.build_with_derived_key(&expanded_key, payer_nonce, payment_id, Some("Paid for coffee"))
+		.unwrap();
+	assert_eq!(proof_with_note.payer_note(), Some("Paid for coffee"));
+
+	// Both proofs should verify and have the same core fields
+	assert_eq!(minimal_proof.preimage(), proof_with_note.preimage());
+	assert_eq!(minimal_proof.payment_hash(), proof_with_note.payment_hash());
+	assert_eq!(minimal_proof.payer_id(), proof_with_note.payer_id());
+	assert_eq!(minimal_proof.issuer_signing_pubkey(), proof_with_note.issuer_signing_pubkey());
+
+	// The merkle roots are the same since both reconstruct from the same invoice
+	assert_eq!(minimal_proof.merkle_root(), proof_with_note.merkle_root());
+
+	// --- Test 6: Round-trip the proof with note through TLV bytes ---
+	let encoded = proof_with_note.to_string();
+	assert!(encoded.starts_with("lnp1"));
+
+	let decoded = PayerProof::try_from(proof_with_note.bytes().to_vec()).unwrap();
+	assert_eq!(decoded.payer_note(), Some("Paid for coffee"));
+	assert_eq!(decoded.preimage(), payment_preimage);
 }

--- a/lightning/src/ln/offers_tests.rs
+++ b/lightning/src/ln/offers_tests.rs
@@ -2889,7 +2889,7 @@ fn creates_payer_proof_with_note_and_selective_disclosure() {
 		.include_invoice_created_at()
 		.build_with_derived_key(&expanded_key, payer_nonce, payment_id, Some("Paid for coffee"))
 		.unwrap();
-	assert_eq!(proof_with_note.payer_note(), Some("Paid for coffee"));
+	assert_eq!(proof_with_note.payer_note().map(|p| p.0), Some("Paid for coffee"));
 
 	// Both proofs should verify and have the same core fields
 	assert_eq!(minimal_proof.preimage(), proof_with_note.preimage());
@@ -2905,6 +2905,6 @@ fn creates_payer_proof_with_note_and_selective_disclosure() {
 	assert!(encoded.starts_with("lnp1"));
 
 	let decoded = PayerProof::try_from(proof_with_note.bytes().to_vec()).unwrap();
-	assert_eq!(decoded.payer_note(), Some("Paid for coffee"));
+	assert_eq!(decoded.payer_note().map(|p| p.0), Some("Paid for coffee"));
 	assert_eq!(decoded.preimage(), payment_preimage);
 }

--- a/lightning/src/offers/invoice.rs
+++ b/lightning/src/offers/invoice.rs
@@ -141,6 +141,7 @@ use crate::offers::offer::{
 };
 use crate::offers::parse::{Bolt12ParseError, Bolt12SemanticError, ParsedMessage};
 use crate::offers::payer::{PayerTlvStream, PayerTlvStreamRef, PAYER_METADATA_TYPE};
+use crate::offers::payer_proof::{PayerProofBuilder, PayerProofError};
 use crate::offers::refund::{
 	Refund, RefundContents, IV_BYTES_WITHOUT_METADATA as REFUND_IV_BYTES_WITHOUT_METADATA,
 	IV_BYTES_WITH_METADATA as REFUND_IV_BYTES_WITH_METADATA,
@@ -148,6 +149,7 @@ use crate::offers::refund::{
 use crate::offers::signer::{self, Metadata};
 use crate::types::features::{Bolt12InvoiceFeatures, InvoiceRequestFeatures, OfferFeatures};
 use crate::types::payment::PaymentHash;
+use crate::types::payment::PaymentPreimage;
 use crate::types::string::PrintableString;
 use crate::util::ser::{
 	CursorReadable, HighZeroBytesDroppedBigSize, Iterable, LengthLimitedRead, LengthReadable,
@@ -1033,6 +1035,17 @@ impl Bolt12Invoice {
 		)
 	}
 
+	/// Creates a [`PayerProofBuilder`] for this invoice using the given payment preimage.
+	///
+	/// Returns an error if the preimage doesn't match the invoice's payment hash.
+	///
+	/// [`PayerProofBuilder`]: crate::offers::payer_proof::PayerProofBuilder
+	pub fn payer_proof_builder(
+		&self, preimage: PaymentPreimage,
+	) -> Result<PayerProofBuilder<'_>, PayerProofError> {
+		PayerProofBuilder::new(self, preimage)
+	}
+
 	/// Re-derives the payer's signing keypair for payer proof creation.
 	///
 	/// This performs the same key derivation that occurs during invoice request creation
@@ -1553,6 +1566,21 @@ impl TryFrom<Vec<u8>> for Bolt12Invoice {
 
 /// Valid type range for invoice TLV records.
 pub(super) const INVOICE_TYPES: core::ops::Range<u64> = 160..240;
+
+/// TLV record type for the invoice creation timestamp.
+pub(super) const INVOICE_CREATED_AT_TYPE: u64 = 164;
+
+/// TLV record type for [`Bolt12Invoice::payment_hash`].
+pub(super) const INVOICE_PAYMENT_HASH_TYPE: u64 = 168;
+
+/// TLV record type for [`Bolt12Invoice::amount_msats`].
+pub(super) const INVOICE_AMOUNT_TYPE: u64 = 170;
+
+/// TLV record type for [`Bolt12Invoice::invoice_features`].
+pub(super) const INVOICE_FEATURES_TYPE: u64 = 174;
+
+/// TLV record type for [`Bolt12Invoice::signing_pubkey`].
+pub(super) const INVOICE_NODE_ID_TYPE: u64 = 176;
 
 tlv_stream!(InvoiceTlvStream, InvoiceTlvStreamRef<'a>, INVOICE_TYPES, {
 	(160, paths: (Vec<BlindedPath>, WithoutLength, Iterable<'a, BlindedPathIter<'a>, BlindedPath>)),

--- a/lightning/src/offers/invoice.rs
+++ b/lightning/src/offers/invoice.rs
@@ -131,7 +131,8 @@ use crate::offers::invoice_request::{
 	IV_BYTES as INVOICE_REQUEST_IV_BYTES,
 };
 use crate::offers::merkle::{
-	self, SignError, SignFn, SignatureTlvStream, SignatureTlvStreamRef, TaggedHash, TlvStream,
+	self, SignError, SignFn, SignatureTlvStream, SignatureTlvStreamRef, TaggedHash, TlvRecord,
+	TlvStream,
 };
 use crate::offers::nonce::Nonce;
 use crate::offers::offer::{
@@ -1032,6 +1033,31 @@ impl Bolt12Invoice {
 		)
 	}
 
+	/// Re-derives the payer's signing keypair for payer proof creation.
+	///
+	/// This performs the same key derivation that occurs during invoice request creation
+	/// with `deriving_signing_pubkey`, allowing the payer to recover their signing keypair.
+	/// The `nonce` and `payment_id` must be the same ones used when creating the original
+	/// invoice request (available from [`OffersContext::OutboundPaymentForOffer`]).
+	///
+	/// [`OffersContext::OutboundPaymentForOffer`]: crate::blinded_path::message::OffersContext::OutboundPaymentForOffer
+	pub(crate) fn derive_payer_signing_keys<T: secp256k1::Signing>(
+		&self, payment_id: PaymentId, nonce: Nonce, key: &ExpandedKey, secp_ctx: &Secp256k1<T>,
+	) -> Result<Keypair, ()> {
+		let iv_bytes = match &self.contents {
+			InvoiceContents::ForOffer { .. } => INVOICE_REQUEST_IV_BYTES,
+			InvoiceContents::ForRefund { .. } => REFUND_IV_BYTES_WITHOUT_METADATA,
+		};
+		self.contents.derive_payer_signing_keys(
+			&self.bytes,
+			payment_id,
+			nonce,
+			key,
+			iv_bytes,
+			secp_ctx,
+		)
+	}
+
 	pub(crate) fn as_tlv_stream(&self) -> FullInvoiceTlvStreamRef<'_> {
 		let (
 			payer_tlv_stream,
@@ -1317,20 +1343,8 @@ impl InvoiceContents {
 		&self, bytes: &[u8], metadata: &Metadata, key: &ExpandedKey, iv_bytes: &[u8; IV_LEN],
 		secp_ctx: &Secp256k1<T>,
 	) -> Result<PaymentId, ()> {
-		const EXPERIMENTAL_TYPES: core::ops::Range<u64> =
-			EXPERIMENTAL_OFFER_TYPES.start..EXPERIMENTAL_INVOICE_REQUEST_TYPES.end;
-
-		let offer_records = TlvStream::new(bytes).range(OFFER_TYPES);
-		let invreq_records = TlvStream::new(bytes).range(INVOICE_REQUEST_TYPES).filter(|record| {
-			match record.r#type {
-				PAYER_METADATA_TYPE => false, // Should be outside range
-				INVOICE_REQUEST_PAYER_ID_TYPE => !metadata.derives_payer_keys(),
-				_ => true,
-			}
-		});
-		let experimental_records = TlvStream::new(bytes).range(EXPERIMENTAL_TYPES);
-		let tlv_stream = offer_records.chain(invreq_records).chain(experimental_records);
-
+		let exclude_payer_id = metadata.derives_payer_keys();
+		let tlv_stream = Self::payer_tlv_stream(bytes, exclude_payer_id);
 		let signing_pubkey = self.payer_signing_pubkey();
 		signer::verify_payer_metadata(
 			metadata.as_ref(),
@@ -1340,6 +1354,46 @@ impl InvoiceContents {
 			tlv_stream,
 			secp_ctx,
 		)
+	}
+
+	fn derive_payer_signing_keys<T: secp256k1::Signing>(
+		&self, bytes: &[u8], payment_id: PaymentId, nonce: Nonce, key: &ExpandedKey,
+		iv_bytes: &[u8; IV_LEN], secp_ctx: &Secp256k1<T>,
+	) -> Result<Keypair, ()> {
+		let tlv_stream = Self::payer_tlv_stream(bytes, true);
+		let signing_pubkey = self.payer_signing_pubkey();
+		signer::derive_payer_keys(
+			payment_id,
+			nonce,
+			key,
+			iv_bytes,
+			signing_pubkey,
+			tlv_stream,
+			secp_ctx,
+		)
+	}
+
+	/// Builds the TLV stream used for payer metadata verification and key derivation.
+	///
+	/// When `exclude_payer_id` is true, the payer signing pubkey (type 88) is excluded
+	/// from the stream, which is needed when deriving payer keys.
+	fn payer_tlv_stream(
+		bytes: &[u8], exclude_payer_id: bool,
+	) -> impl core::iter::Iterator<Item = TlvRecord<'_>> {
+		const EXPERIMENTAL_TYPES: core::ops::Range<u64> =
+			EXPERIMENTAL_OFFER_TYPES.start..EXPERIMENTAL_INVOICE_REQUEST_TYPES.end;
+
+		let offer_records = TlvStream::new(bytes).range(OFFER_TYPES);
+		let invreq_records =
+			TlvStream::new(bytes).range(INVOICE_REQUEST_TYPES).filter(move |record| {
+				match record.r#type {
+					PAYER_METADATA_TYPE => false,
+					INVOICE_REQUEST_PAYER_ID_TYPE => !exclude_payer_id,
+					_ => true,
+				}
+			});
+		let experimental_records = TlvStream::new(bytes).range(EXPERIMENTAL_TYPES);
+		offer_records.chain(invreq_records).chain(experimental_records)
 	}
 
 	fn as_tlv_stream(&self) -> PartialInvoiceTlvStreamRef<'_> {

--- a/lightning/src/offers/merkle.rs
+++ b/lightning/src/offers/merkle.rs
@@ -250,7 +250,17 @@ pub(super) struct TlvRecord<'a> {
 	type_bytes: &'a [u8],
 	// The entire TLV record.
 	pub(super) record_bytes: &'a [u8],
+	// The value portion of the TLV record (after type and length).
+	pub(super) value_bytes: &'a [u8],
 	pub(super) end: usize,
+}
+
+impl<'a> TlvRecord<'a> {
+	/// Read a value from this TLV record's value bytes using [`Readable`].
+	pub(super) fn read_value<T: Readable>(&self) -> Result<T, crate::ln::msgs::DecodeError> {
+		let mut cursor = io::Cursor::new(self.value_bytes);
+		Readable::read(&mut cursor)
+	}
 }
 
 impl<'a> Iterator for TlvStream<'a> {
@@ -269,10 +279,11 @@ impl<'a> Iterator for TlvStream<'a> {
 			let end = offset + length;
 
 			let record_bytes = &self.data.get_ref()[start as usize..end as usize];
+			let value_bytes = &self.data.get_ref()[offset as usize..end as usize];
 
 			self.data.set_position(end);
 
-			Some(TlvRecord { r#type, type_bytes, record_bytes, end: end as usize })
+			Some(TlvRecord { r#type, type_bytes, record_bytes, value_bytes, end: end as usize })
 		} else {
 			None
 		}
@@ -381,31 +392,25 @@ pub(super) fn compute_selective_disclosure(
 }
 
 /// Compute omitted markers per BOLT 12 payer proof spec.
+///
+/// Each omitted TLV gets a marker equal to `prev_value + 1`, where `prev_value`
+/// tracks the last included type or last marker. TLV type 0 is implicitly
+/// omitted (never included in markers).
 fn compute_omitted_markers(tlv_data: &[TlvMerkleData]) -> Vec<u64> {
 	let mut markers = Vec::new();
-	let mut prev_included_type: Option<u64> = None;
-	let mut prev_marker: Option<u64> = None;
+	let mut prev_value: u64 = 0;
 
 	for data in tlv_data {
 		if data.tlv_type == 0 {
 			continue;
 		}
 
-		if !data.is_included {
-			let marker = if let Some(prev_type) = prev_included_type {
-				prev_type + 1
-			} else if let Some(last_marker) = prev_marker {
-				last_marker + 1
-			} else {
-				1
-			};
-
-			markers.push(marker);
-			prev_marker = Some(marker);
-			prev_included_type = None;
+		if data.is_included {
+			prev_value = data.tlv_type;
 		} else {
-			prev_included_type = Some(data.tlv_type);
-			prev_marker = None;
+			let marker = prev_value + 1;
+			markers.push(marker);
+			prev_value = marker;
 		}
 	}
 
@@ -462,37 +467,23 @@ fn build_tree_with_disclosure(
 			let right_incl = nodes[right_pos].included;
 			let right_min_type = nodes[right_pos].min_type;
 
-			match (left_hash, right_hash, left_incl, right_incl) {
-				(Some(l), Some(r), true, false) => {
-					missing_with_types.push((right_min_type, r));
+			match (left_hash, right_hash) {
+				(Some(l), Some(r)) => {
+					if left_incl != right_incl {
+						let (missing_type, missing_hash) = if right_incl {
+							(nodes[left_pos].min_type, l)
+						} else {
+							(right_min_type, r)
+						};
+						missing_with_types.push((missing_type, missing_hash));
+					}
 					nodes[left_pos].hash =
 						Some(tagged_branch_hash_from_engine(branch_tag.clone(), l, r));
-					nodes[left_pos].included = true;
+					nodes[left_pos].included |= left_incl || right_incl;
 					nodes[left_pos].min_type =
 						core::cmp::min(nodes[left_pos].min_type, right_min_type);
 				},
-				(Some(l), Some(r), false, true) => {
-					missing_with_types.push((nodes[left_pos].min_type, l));
-					let left_min = nodes[left_pos].min_type;
-					nodes[left_pos].hash =
-						Some(tagged_branch_hash_from_engine(branch_tag.clone(), l, r));
-					nodes[left_pos].included = true;
-					nodes[left_pos].min_type = core::cmp::min(left_min, right_min_type);
-				},
-				(Some(l), Some(r), true, true) => {
-					nodes[left_pos].hash =
-						Some(tagged_branch_hash_from_engine(branch_tag.clone(), l, r));
-					nodes[left_pos].included = true;
-					nodes[left_pos].min_type =
-						core::cmp::min(nodes[left_pos].min_type, right_min_type);
-				},
-				(Some(l), Some(r), false, false) => {
-					nodes[left_pos].hash =
-						Some(tagged_branch_hash_from_engine(branch_tag.clone(), l, r));
-					nodes[left_pos].min_type =
-						core::cmp::min(nodes[left_pos].min_type, right_min_type);
-				},
-				(Some(_), None, _, _) => {},
+				(Some(_), None) => {},
 				_ => unreachable!("Invalid state in merkle tree construction"),
 			}
 		}

--- a/lightning/src/offers/mod.rs
+++ b/lightning/src/offers/mod.rs
@@ -25,6 +25,7 @@ pub mod merkle;
 pub mod nonce;
 pub mod parse;
 mod payer;
+pub mod payer_proof;
 pub mod refund;
 pub(crate) mod signer;
 pub mod static_invoice;

--- a/lightning/src/offers/offer.rs
+++ b/lightning/src/offers/offer.rs
@@ -1211,6 +1211,12 @@ pub(super) const OFFER_TYPES: core::ops::Range<u64> = 1..80;
 /// TLV record type for [`Offer::metadata`].
 const OFFER_METADATA_TYPE: u64 = 4;
 
+/// TLV record type for [`Offer::description`].
+pub(super) const OFFER_DESCRIPTION_TYPE: u64 = 10;
+
+/// TLV record type for [`Offer::issuer`].
+pub(super) const OFFER_ISSUER_TYPE: u64 = 18;
+
 /// TLV record type for [`Offer::issuer_signing_pubkey`].
 const OFFER_ISSUER_ID_TYPE: u64 = 22;
 

--- a/lightning/src/offers/payer_proof.rs
+++ b/lightning/src/offers/payer_proof.rs
@@ -83,6 +83,9 @@ pub enum PayerProofError {
 	InvalidData(&'static str),
 	/// The invreq_metadata field cannot be included (per spec).
 	InvreqMetadataNotAllowed,
+	/// Signature-range TLV types (240-1000) cannot be included — they are
+	/// handled separately by the payer proof format.
+	SignatureTypeNotAllowed,
 	/// The omitted_markers contains an included TLV type.
 	OmittedMarkersContainIncluded,
 	/// The omitted_markers has too many trailing markers.
@@ -162,10 +165,14 @@ impl<'a> PayerProofBuilder<'a> {
 
 	/// Include a specific TLV type in the proof.
 	///
-	/// Returns an error if the type is not allowed (e.g., invreq_metadata).
+	/// Returns an error if the type is not allowed (e.g., invreq_metadata or
+	/// signature-range types 240-1000 which are handled separately).
 	pub fn include_type(mut self, tlv_type: u64) -> Result<Self, PayerProofError> {
 		if tlv_type == PAYER_METADATA_TYPE {
 			return Err(PayerProofError::InvreqMetadataNotAllowed);
+		}
+		if SIGNATURE_TYPES.contains(&tlv_type) {
+			return Err(PayerProofError::SignatureTypeNotAllowed);
 		}
 		self.included_types.insert(tlv_type);
 		Ok(self)
@@ -318,9 +325,12 @@ impl UnsignedPayerProof {
 	fn serialize_payer_proof(&self, payer_signature: &Signature, note: Option<&str>) -> Vec<u8> {
 		let mut bytes = Vec::new();
 
-		for record in
-			TlvStream::new(&self.invoice_bytes).filter(|r| self.included_types.contains(&r.r#type))
-		{
+		// Filter out SIGNATURE_TYPES defensively: the invoice bytes contain the
+		// invoice's own signature (type 240) which must not appear as an included
+		// invoice record — the payer proof writes its own signature TLV below.
+		for record in TlvStream::new(&self.invoice_bytes).filter(|r| {
+			self.included_types.contains(&r.r#type) && !SIGNATURE_TYPES.contains(&r.r#type)
+		}) {
 			bytes.extend_from_slice(record.record_bytes);
 		}
 
@@ -1060,5 +1070,72 @@ mod tests {
 
 		let result = PayerProof::try_from(bytes);
 		assert!(result.is_err());
+	}
+
+	/// Test that signature-range TLV types (240-1000) are rejected by include_type.
+	///
+	/// Per spec, the signature (type 240) is handled separately by the payer proof
+	/// format. Allowing include_type(240) would produce a malformed TLV stream with
+	/// duplicate type 240: once from the included invoice records loop, and again
+	/// from the explicit signature serialization.
+	#[test]
+	fn test_include_type_rejects_signature_types() {
+		// Test the type validation logic directly via a minimal PayerProofBuilder.
+		// We construct a builder with empty included_types and test include_type.
+		let mut included_types = BTreeSet::new();
+		included_types.insert(INVOICE_REQUEST_PAYER_ID_TYPE);
+
+		// Simulate what include_type does, testing the guard:
+		// Type 240 (TLV_SIGNATURE) — in SIGNATURE_TYPES, must be rejected
+		assert!(SIGNATURE_TYPES.contains(&240));
+		assert!(SIGNATURE_TYPES.contains(&250));
+		assert!(SIGNATURE_TYPES.contains(&1000));
+		assert!(!SIGNATURE_TYPES.contains(&239));
+		assert!(!SIGNATURE_TYPES.contains(&1001));
+
+		// Now test via the actual error path by checking PayerProofError variant
+		// exists and the guard condition works:
+		fn check_include_type(tlv_type: u64) -> Result<(), PayerProofError> {
+			if tlv_type == PAYER_METADATA_TYPE {
+				return Err(PayerProofError::InvreqMetadataNotAllowed);
+			}
+			if SIGNATURE_TYPES.contains(&tlv_type) {
+				return Err(PayerProofError::SignatureTypeNotAllowed);
+			}
+			Ok(())
+		}
+
+		// Signature range boundaries
+		assert!(matches!(check_include_type(240), Err(PayerProofError::SignatureTypeNotAllowed)));
+		assert!(matches!(check_include_type(250), Err(PayerProofError::SignatureTypeNotAllowed)));
+		assert!(matches!(check_include_type(1000), Err(PayerProofError::SignatureTypeNotAllowed)));
+		// Just outside the range
+		assert!(check_include_type(239).is_ok());
+		assert!(check_include_type(1001).is_ok());
+		// Payer metadata still rejected
+		assert!(matches!(check_include_type(0), Err(PayerProofError::InvreqMetadataNotAllowed)));
+	}
+
+	/// Test that unknown even TLV types >= 240 are rejected during parsing.
+	///
+	/// Per BOLT convention, even types are mandatory-to-understand. The parser
+	/// must reject unknown even types in the signature range to prevent
+	/// accepting malformed proofs.
+	#[test]
+	fn test_parsing_rejects_unknown_even_signature_range_types() {
+		use core::convert::TryFrom;
+
+		// Craft a payer proof with an unknown even type 252 (in signature range,
+		// but not one of the known payer proof TLVs)
+		let mut bytes = Vec::new();
+		// Some included invoice TLV first (type 10)
+		bytes.extend_from_slice(&[0x0a, 0x02, 0x00, 0x00]);
+		// Unknown even type 252 (in signature range 240-1000)
+		bytes.push(0xfc); // type 252
+		bytes.push(0x02); // length 2
+		bytes.extend_from_slice(&[0x00, 0x00]);
+
+		let result = PayerProof::try_from(bytes);
+		assert!(result.is_err(), "Unknown even type 252 should be rejected");
 	}
 }

--- a/lightning/src/offers/payer_proof.rs
+++ b/lightning/src/offers/payer_proof.rs
@@ -20,7 +20,6 @@
 use alloc::collections::BTreeSet;
 
 use crate::io;
-use crate::io::Read;
 use crate::ln::channelmanager::PaymentId;
 use crate::ln::inbound_payment::ExpandedKey;
 use crate::offers::invoice::{
@@ -37,6 +36,7 @@ use crate::offers::parse::Bech32Encode;
 use crate::offers::payer::PAYER_METADATA_TYPE;
 use crate::types::payment::{PaymentHash, PaymentPreimage};
 use crate::util::ser::{BigSize, Readable, Writeable};
+use lightning_types::string::PrintableString;
 
 use bitcoin::hashes::{sha256, Hash, HashEngine};
 use bitcoin::secp256k1::schnorr::Signature;
@@ -76,19 +76,12 @@ pub enum PayerProofError {
 	KeyDerivationFailed,
 	/// Error during signing.
 	SigningError,
-	/// Missing required field in the proof.
-	MissingRequiredField(&'static str),
-	/// The proof contains invalid data.
-	InvalidData(&'static str),
 	/// The invreq_metadata field cannot be included (per spec).
 	InvreqMetadataNotAllowed,
 	/// TLV types >= 240 cannot be included — they are in the
 	/// signature/payer-proof range and handled separately.
 	SignatureTypeNotAllowed,
-	/// The omitted_markers contains an included TLV type.
-	OmittedMarkersContainIncluded,
-	/// The omitted_markers has too many trailing markers.
-	TooManyTrailingOmittedMarkers,
+
 	/// Error decoding the payer proof.
 	DecodeError(crate::ln::msgs::DecodeError),
 }
@@ -136,6 +129,7 @@ pub struct PayerProofBuilder<'a> {
 	invoice: &'a Bolt12Invoice,
 	preimage: PaymentPreimage,
 	included_types: BTreeSet<u64>,
+	invoice_bytes: Vec<u8>,
 }
 
 impl<'a> PayerProofBuilder<'a> {
@@ -150,6 +144,9 @@ impl<'a> PayerProofBuilder<'a> {
 			return Err(PayerProofError::PreimageMismatch);
 		}
 
+		let mut invoice_bytes = Vec::new();
+		invoice.write(&mut invoice_bytes).expect("Vec write should not fail");
+
 		let mut included_types = BTreeSet::new();
 		included_types.insert(INVOICE_REQUEST_PAYER_ID_TYPE);
 		included_types.insert(INVOICE_PAYMENT_HASH_TYPE);
@@ -159,15 +156,13 @@ impl<'a> PayerProofBuilder<'a> {
 		// TLV exists in the invoice byte stream, regardless of whether the parsed
 		// value is empty. Check the raw bytes so we handle invoices from other
 		// implementations that may serialize empty features.
-		let mut invoice_bytes = Vec::new();
-		invoice.write(&mut invoice_bytes).expect("Vec write should not fail");
 		let has_features_tlv =
 			TlvStream::new(&invoice_bytes).any(|r| r.r#type == INVOICE_FEATURES_TYPE);
 		if has_features_tlv {
 			included_types.insert(INVOICE_FEATURES_TYPE);
 		}
 
-		Ok(Self { invoice, preimage, included_types })
+		Ok(Self { invoice, preimage, included_types, invoice_bytes })
 	}
 
 	/// Include a specific TLV type in the proof.
@@ -243,8 +238,7 @@ impl<'a> PayerProofBuilder<'a> {
 	}
 
 	fn build_unsigned(self) -> Result<UnsignedPayerProof, PayerProofError> {
-		let mut invoice_bytes = Vec::new();
-		self.invoice.write(&mut invoice_bytes).expect("Vec write should not fail");
+		let invoice_bytes = self.invoice_bytes;
 		let mut bytes_without_sig = Vec::with_capacity(invoice_bytes.len());
 		for r in TlvStream::new(&invoice_bytes).filter(|r| !SIGNATURE_TYPES.contains(&r.r#type)) {
 			bytes_without_sig.extend_from_slice(r.record_bytes);
@@ -425,8 +419,8 @@ impl PayerProof {
 	}
 
 	/// The payer's note, if any.
-	pub fn payer_note(&self) -> Option<&str> {
-		self.contents.payer_note.as_deref()
+	pub fn payer_note(&self) -> Option<PrintableString> {
+		self.contents.payer_note.as_deref().map(PrintableString)
 	}
 
 	/// The merkle root of the original invoice.
@@ -448,15 +442,6 @@ impl AsRef<[u8]> for PayerProof {
 	fn as_ref(&self) -> &[u8] {
 		&self.bytes
 	}
-}
-
-/// Read a value from a TLV record's raw bytes, skipping the type and length
-/// prefix.
-fn read_tlv_value<T: Readable>(record_bytes: &[u8]) -> Result<T, crate::ln::msgs::DecodeError> {
-	let mut cursor = io::Cursor::new(record_bytes);
-	let _type: BigSize = Readable::read(&mut cursor)?;
-	let _len: BigSize = Readable::read(&mut cursor)?;
-	Readable::read(&mut cursor)
 }
 
 /// Validate that the byte slice is a well-formed TLV stream.
@@ -532,7 +517,7 @@ impl TryFrom<Vec<u8>> for PayerProof {
 
 			match tlv_type {
 				INVOICE_REQUEST_PAYER_ID_TYPE => {
-					payer_id = Some(read_tlv_value(record.record_bytes)?);
+					payer_id = Some(record.read_value()?);
 					included_types.insert(tlv_type);
 					included_records.push((
 						tlv_type,
@@ -541,7 +526,7 @@ impl TryFrom<Vec<u8>> for PayerProof {
 					));
 				},
 				INVOICE_PAYMENT_HASH_TYPE => {
-					payment_hash = Some(read_tlv_value(record.record_bytes)?);
+					payment_hash = Some(record.read_value()?);
 					included_types.insert(tlv_type);
 					included_records.push((
 						tlv_type,
@@ -550,7 +535,7 @@ impl TryFrom<Vec<u8>> for PayerProof {
 					));
 				},
 				INVOICE_NODE_ID_TYPE => {
-					issuer_signing_pubkey = Some(read_tlv_value(record.record_bytes)?);
+					issuer_signing_pubkey = Some(record.read_value()?);
 					included_types.insert(tlv_type);
 					included_records.push((
 						tlv_type,
@@ -559,81 +544,47 @@ impl TryFrom<Vec<u8>> for PayerProof {
 					));
 				},
 				TLV_SIGNATURE => {
-					let mut record_cursor = io::Cursor::new(record.record_bytes);
-					let _type: BigSize = Readable::read(&mut record_cursor)?;
-					let _len: BigSize = Readable::read(&mut record_cursor)?;
-					invoice_signature = Some(Readable::read(&mut record_cursor)?);
+					invoice_signature = Some(record.read_value()?);
 				},
 				TLV_PREIMAGE => {
-					let mut record_cursor = io::Cursor::new(record.record_bytes);
-					let _type: BigSize = Readable::read(&mut record_cursor)?;
-					let _len: BigSize = Readable::read(&mut record_cursor)?;
-					let mut preimage_bytes = [0u8; 32];
-					record_cursor
-						.read_exact(&mut preimage_bytes)
-						.map_err(|_| DecodeError::ShortRead)?;
-					preimage = Some(PaymentPreimage(preimage_bytes));
+					preimage = Some(record.read_value()?);
 				},
 				TLV_OMITTED_TLVS => {
-					let mut record_cursor = io::Cursor::new(record.record_bytes);
-					let _type: BigSize = Readable::read(&mut record_cursor)?;
-					let len: BigSize = Readable::read(&mut record_cursor)?;
-					let end_pos = record_cursor.position() + len.0;
-					while record_cursor.position() < end_pos {
-						let marker: BigSize = Readable::read(&mut record_cursor)?;
+					let mut cursor = io::Cursor::new(record.value_bytes);
+					while (cursor.position() as usize) < record.value_bytes.len() {
+						let marker: BigSize = Readable::read(&mut cursor)?;
 						omitted_markers.push(marker.0);
 					}
 				},
 				TLV_MISSING_HASHES => {
-					let mut record_cursor = io::Cursor::new(record.record_bytes);
-					let _type: BigSize = Readable::read(&mut record_cursor)?;
-					let len: BigSize = Readable::read(&mut record_cursor)?;
-					if len.0 % 32 != 0 {
+					if record.value_bytes.len() % 32 != 0 {
 						return Err(Bolt12ParseError::Decode(DecodeError::InvalidValue));
 					}
-					let num_hashes = len.0 / 32;
-					for _ in 0..num_hashes {
-						let mut hash_bytes = [0u8; 32];
-						record_cursor
-							.read_exact(&mut hash_bytes)
-							.map_err(|_| DecodeError::ShortRead)?;
+					for chunk in record.value_bytes.chunks_exact(32) {
+						let hash_bytes: [u8; 32] = chunk.try_into().expect("chunks_exact(32)");
 						missing_hashes.push(sha256::Hash::from_byte_array(hash_bytes));
 					}
 				},
 				TLV_LEAF_HASHES => {
-					let mut record_cursor = io::Cursor::new(record.record_bytes);
-					let _type: BigSize = Readable::read(&mut record_cursor)?;
-					let len: BigSize = Readable::read(&mut record_cursor)?;
-					if len.0 % 32 != 0 {
+					if record.value_bytes.len() % 32 != 0 {
 						return Err(Bolt12ParseError::Decode(DecodeError::InvalidValue));
 					}
-					let num_hashes = len.0 / 32;
-					for _ in 0..num_hashes {
-						let mut hash_bytes = [0u8; 32];
-						record_cursor
-							.read_exact(&mut hash_bytes)
-							.map_err(|_| DecodeError::ShortRead)?;
+					for chunk in record.value_bytes.chunks_exact(32) {
+						let hash_bytes: [u8; 32] = chunk.try_into().expect("chunks_exact(32)");
 						leaf_hashes.push(sha256::Hash::from_byte_array(hash_bytes));
 					}
 				},
 				TLV_PAYER_SIGNATURE => {
-					let mut record_cursor = io::Cursor::new(record.record_bytes);
-					let _type: BigSize = Readable::read(&mut record_cursor)?;
-					let len: BigSize = Readable::read(&mut record_cursor)?;
-					if len.0 < 64 {
+					if record.value_bytes.len() < 64 {
 						return Err(Bolt12ParseError::Decode(DecodeError::InvalidValue));
 					}
-					payer_signature = Some(Readable::read(&mut record_cursor)?);
-					let note_len = len.0 - 64;
-					if note_len > 0 {
-						let note_len_usize =
-							usize::try_from(note_len).map_err(|_| DecodeError::InvalidValue)?;
-						let mut note_bytes = vec![0u8; note_len_usize];
-						record_cursor
-							.read_exact(&mut note_bytes)
-							.map_err(|_| DecodeError::ShortRead)?;
+					let mut cursor = io::Cursor::new(record.value_bytes);
+					payer_signature = Some(Readable::read(&mut cursor)?);
+					if record.value_bytes.len() > 64 {
+						let note_bytes = &record.value_bytes[64..];
 						payer_note = Some(
-							String::from_utf8(note_bytes).map_err(|_| DecodeError::InvalidValue)?,
+							String::from_utf8(note_bytes.to_vec())
+								.map_err(|_| DecodeError::InvalidValue)?,
 						);
 					}
 				},
@@ -679,7 +630,7 @@ impl TryFrom<Vec<u8>> for PayerProof {
 		))?;
 
 		validate_omitted_markers_for_parsing(&omitted_markers, &included_types)
-			.map_err(|_| Bolt12ParseError::Decode(DecodeError::InvalidValue))?;
+			.map_err(Bolt12ParseError::Decode)?;
 
 		if leaf_hashes.len() != included_records.len() {
 			return Err(Bolt12ParseError::Decode(DecodeError::InvalidValue));
@@ -744,7 +695,7 @@ impl TryFrom<Vec<u8>> for PayerProof {
 ///   a run, and the first marker after an included type X must be X + 1
 fn validate_omitted_markers_for_parsing(
 	omitted_markers: &[u64], included_types: &BTreeSet<u64>,
-) -> Result<(), PayerProofError> {
+) -> Result<(), crate::ln::msgs::DecodeError> {
 	let mut inc_iter = included_types.iter().copied().peekable();
 	// After implicit TLV0 (marker 0), the first minimized marker would be 1
 	let mut expected_next: u64 = 1;
@@ -755,22 +706,22 @@ fn validate_omitted_markers_for_parsing(
 	for &marker in omitted_markers {
 		// MUST NOT contain 0
 		if marker == 0 {
-			return Err(PayerProofError::InvalidData("omitted_markers contains 0"));
+			return Err(crate::ln::msgs::DecodeError::InvalidValue);
 		}
 
 		// MUST NOT contain signature TLV types
 		if SIGNATURE_TYPES.contains(&marker) {
-			return Err(PayerProofError::InvalidData("omitted_markers contains signature type"));
+			return Err(crate::ln::msgs::DecodeError::InvalidValue);
 		}
 
 		// MUST be strictly ascending
 		if marker <= prev {
-			return Err(PayerProofError::InvalidData("omitted_markers not strictly ascending"));
+			return Err(crate::ln::msgs::DecodeError::InvalidValue);
 		}
 
 		// MUST NOT contain included TLV types
 		if included_types.contains(&marker) {
-			return Err(PayerProofError::OmittedMarkersContainIncluded);
+			return Err(crate::ln::msgs::DecodeError::InvalidValue);
 		}
 
 		// Validate minimization: marker must equal expected_next (continuation
@@ -784,11 +735,11 @@ fn validate_omitted_markers_for_parsing(
 					break;
 				}
 				if inc_type >= marker {
-					return Err(PayerProofError::InvalidData("omitted_markers not minimized"));
+					return Err(crate::ln::msgs::DecodeError::InvalidValue);
 				}
 			}
 			if !found {
-				return Err(PayerProofError::InvalidData("omitted_markers not minimized"));
+				return Err(crate::ln::msgs::DecodeError::InvalidValue);
 			}
 		}
 
@@ -804,7 +755,7 @@ fn validate_omitted_markers_for_parsing(
 
 	// MUST NOT contain more than one number larger than largest included
 	if trailing_count > 1 {
-		return Err(PayerProofError::TooManyTrailingOmittedMarkers);
+		return Err(crate::ln::msgs::DecodeError::InvalidValue);
 	}
 
 	Ok(())
@@ -932,7 +883,7 @@ mod tests {
 		let included: BTreeSet<u64> = [10, 30].iter().copied().collect();
 
 		let result = validate_omitted_markers_for_parsing(&omitted, &included);
-		assert!(matches!(result, Err(PayerProofError::InvalidData(_))));
+		assert!(result.is_err());
 	}
 
 	/// Test validation of omitted_markers - must not contain signature types.
@@ -943,7 +894,7 @@ mod tests {
 		let included: BTreeSet<u64> = [10].iter().copied().collect();
 
 		let result = validate_omitted_markers_for_parsing(&omitted, &included);
-		assert!(matches!(result, Err(PayerProofError::InvalidData(_))));
+		assert!(result.is_err());
 	}
 
 	/// Test validation of omitted_markers - must be strictly ascending.
@@ -954,7 +905,7 @@ mod tests {
 		let included: BTreeSet<u64> = [10, 30].iter().copied().collect();
 
 		let result = validate_omitted_markers_for_parsing(&omitted, &included);
-		assert!(matches!(result, Err(PayerProofError::InvalidData(_))));
+		assert!(result.is_err());
 	}
 
 	/// Test validation of omitted_markers - must not contain included types.
@@ -965,7 +916,7 @@ mod tests {
 		let included: BTreeSet<u64> = [10, 30].iter().copied().collect();
 
 		let result = validate_omitted_markers_for_parsing(&omitted, &included);
-		assert!(matches!(result, Err(PayerProofError::OmittedMarkersContainIncluded)));
+		assert!(matches!(result, Err(crate::ln::msgs::DecodeError::InvalidValue)));
 	}
 
 	/// Test validation of omitted_markers - must not have too many trailing markers.
@@ -976,7 +927,7 @@ mod tests {
 		let included: BTreeSet<u64> = [10, 20].iter().copied().collect();
 
 		let result = validate_omitted_markers_for_parsing(&omitted, &included);
-		assert!(matches!(result, Err(PayerProofError::TooManyTrailingOmittedMarkers)));
+		assert!(matches!(result, Err(crate::ln::msgs::DecodeError::InvalidValue)));
 	}
 
 	/// Test that valid minimized omitted_markers pass validation.
@@ -1003,7 +954,7 @@ mod tests {
 		let included: BTreeSet<u64> = [10, 40].iter().copied().collect();
 
 		let result = validate_omitted_markers_for_parsing(&omitted, &included);
-		assert!(matches!(result, Err(PayerProofError::InvalidData(_))));
+		assert!(result.is_err());
 	}
 
 	/// Test that non-minimized first marker in a run is rejected.
@@ -1015,7 +966,7 @@ mod tests {
 		let included: BTreeSet<u64> = [10, 40].iter().copied().collect();
 
 		let result = validate_omitted_markers_for_parsing(&omitted, &included);
-		assert!(matches!(result, Err(PayerProofError::InvalidData(_))));
+		assert!(result.is_err());
 	}
 
 	/// Test minimized markers with omitted TLVs before any included type.

--- a/lightning/src/offers/payer_proof.rs
+++ b/lightning/src/offers/payer_proof.rs
@@ -82,8 +82,8 @@ pub enum PayerProofError {
 	InvalidData(&'static str),
 	/// The invreq_metadata field cannot be included (per spec).
 	InvreqMetadataNotAllowed,
-	/// Signature-range TLV types (240-1000) cannot be included — they are
-	/// handled separately by the payer proof format.
+	/// TLV types >= 240 cannot be included — they are in the
+	/// signature/payer-proof range and handled separately.
 	SignatureTypeNotAllowed,
 	/// The omitted_markers contains an included TLV type.
 	OmittedMarkersContainIncluded,
@@ -173,12 +173,13 @@ impl<'a> PayerProofBuilder<'a> {
 	/// Include a specific TLV type in the proof.
 	///
 	/// Returns an error if the type is not allowed (e.g., invreq_metadata or
-	/// signature-range types 240-1000 which are handled separately).
+	/// types >= 240 which are in the signature/payer-proof range and handled
+	/// separately).
 	pub fn include_type(mut self, tlv_type: u64) -> Result<Self, PayerProofError> {
 		if tlv_type == PAYER_METADATA_TYPE {
 			return Err(PayerProofError::InvreqMetadataNotAllowed);
 		}
-		if SIGNATURE_TYPES.contains(&tlv_type) {
+		if tlv_type >= TLV_SIGNATURE {
 			return Err(PayerProofError::SignatureTypeNotAllowed);
 		}
 		self.included_types.insert(tlv_type);
@@ -458,6 +459,27 @@ fn read_tlv_value<T: Readable>(record_bytes: &[u8]) -> Result<T, crate::ln::msgs
 	Readable::read(&mut cursor)
 }
 
+/// Validate that the byte slice is a well-formed TLV stream.
+///
+/// `TlvStream::new()` assumes well-formed input and panics on malformed BigSize
+/// values or out-of-bounds lengths. This function validates the framing first,
+/// returning an error instead of panicking on untrusted input.
+fn validate_tlv_framing(bytes: &[u8]) -> Result<(), crate::ln::msgs::DecodeError> {
+	use crate::ln::msgs::DecodeError;
+	let mut cursor = io::Cursor::new(bytes);
+	while (cursor.position() as usize) < bytes.len() {
+		let _type: BigSize = Readable::read(&mut cursor).map_err(|_| DecodeError::InvalidValue)?;
+		let length: BigSize = Readable::read(&mut cursor).map_err(|_| DecodeError::InvalidValue)?;
+		let end = cursor.position().checked_add(length.0).ok_or(DecodeError::InvalidValue)?;
+		let end_usize = usize::try_from(end).map_err(|_| DecodeError::InvalidValue)?;
+		if end_usize > bytes.len() {
+			return Err(DecodeError::ShortRead);
+		}
+		cursor.set_position(end);
+	}
+	Ok(())
+}
+
 // Payer proofs use manual TLV parsing rather than `ParsedMessage` / `tlv_stream!`
 // because of their hybrid structure: a dynamic, variable set of included invoice
 // TLV records (types 0-239, preserved as raw bytes for merkle reconstruction) plus
@@ -472,6 +494,13 @@ impl TryFrom<Vec<u8>> for PayerProof {
 	fn try_from(bytes: Vec<u8>) -> Result<Self, Self::Error> {
 		use crate::ln::msgs::DecodeError;
 		use crate::offers::parse::Bolt12ParseError;
+
+		// Validate TLV framing before passing to TlvStream, which assumes
+		// well-formed input and panics on malformed BigSize or out-of-bounds
+		// lengths. This mirrors the validation that ParsedMessage / CursorReadable
+		// provides for other BOLT 12 types.
+		validate_tlv_framing(&bytes)
+			.map_err(|_| Bolt12ParseError::Decode(DecodeError::InvalidValue))?;
 
 		let mut payer_id: Option<PublicKey> = None;
 		let mut payment_hash: Option<PaymentHash> = None;
@@ -488,16 +517,18 @@ impl TryFrom<Vec<u8>> for PayerProof {
 		let mut included_types: BTreeSet<u64> = BTreeSet::new();
 		let mut included_records: Vec<(u64, usize, usize)> = Vec::new();
 
-		let mut prev_tlv_type: u64 = 0;
+		let mut prev_tlv_type: Option<u64> = None;
 
 		for record in TlvStream::new(&bytes) {
 			let tlv_type = record.r#type;
 
 			// Strict ascending order check covers both ordering and duplicates.
-			if tlv_type <= prev_tlv_type && prev_tlv_type != 0 {
-				return Err(Bolt12ParseError::Decode(DecodeError::InvalidValue));
+			if let Some(prev) = prev_tlv_type {
+				if tlv_type <= prev {
+					return Err(Bolt12ParseError::Decode(DecodeError::InvalidValue));
+				}
 			}
-			prev_tlv_type = tlv_type;
+			prev_tlv_type = Some(tlv_type);
 
 			match tlv_type {
 				INVOICE_REQUEST_PAYER_ID_TYPE => {
@@ -589,10 +620,15 @@ impl TryFrom<Vec<u8>> for PayerProof {
 					let mut record_cursor = io::Cursor::new(record.record_bytes);
 					let _type: BigSize = Readable::read(&mut record_cursor)?;
 					let len: BigSize = Readable::read(&mut record_cursor)?;
+					if len.0 < 64 {
+						return Err(Bolt12ParseError::Decode(DecodeError::InvalidValue));
+					}
 					payer_signature = Some(Readable::read(&mut record_cursor)?);
-					let note_len = len.0.saturating_sub(64);
+					let note_len = len.0 - 64;
 					if note_len > 0 {
-						let mut note_bytes = vec![0u8; note_len as usize];
+						let note_len_usize =
+							usize::try_from(note_len).map_err(|_| DecodeError::InvalidValue)?;
+						let mut note_bytes = vec![0u8; note_len_usize];
 						record_cursor
 							.read_exact(&mut note_bytes)
 							.map_err(|_| DecodeError::ShortRead)?;
@@ -1079,46 +1115,36 @@ mod tests {
 		assert!(result.is_err());
 	}
 
-	/// Test that signature-range TLV types (240-1000) are rejected by include_type.
+	/// Test that TLV types >= 240 are rejected by include_type.
 	///
-	/// Per spec, the signature (type 240) is handled separately by the payer proof
-	/// format. Allowing include_type(240) would produce a malformed TLV stream with
-	/// duplicate type 240: once from the included invoice records loop, and again
-	/// from the explicit signature serialization.
+	/// Per spec, all types >= 240 are in the signature/payer-proof range and
+	/// handled separately. This includes types > 1000 (experimental range)
+	/// which were previously allowed through.
 	#[test]
 	fn test_include_type_rejects_signature_types() {
-		// Test the type validation logic directly via a minimal PayerProofBuilder.
-		// We construct a builder with empty included_types and test include_type.
-		let mut included_types = BTreeSet::new();
-		included_types.insert(INVOICE_REQUEST_PAYER_ID_TYPE);
-
-		// Simulate what include_type does, testing the guard:
-		// Type 240 (TLV_SIGNATURE) — in SIGNATURE_TYPES, must be rejected
-		assert!(SIGNATURE_TYPES.contains(&240));
-		assert!(SIGNATURE_TYPES.contains(&250));
-		assert!(SIGNATURE_TYPES.contains(&1000));
-		assert!(!SIGNATURE_TYPES.contains(&239));
-		assert!(!SIGNATURE_TYPES.contains(&1001));
-
-		// Now test via the actual error path by checking PayerProofError variant
-		// exists and the guard condition works:
+		// Test the type validation logic directly.
 		fn check_include_type(tlv_type: u64) -> Result<(), PayerProofError> {
 			if tlv_type == PAYER_METADATA_TYPE {
 				return Err(PayerProofError::InvreqMetadataNotAllowed);
 			}
-			if SIGNATURE_TYPES.contains(&tlv_type) {
+			if tlv_type >= TLV_SIGNATURE {
 				return Err(PayerProofError::SignatureTypeNotAllowed);
 			}
 			Ok(())
 		}
 
-		// Signature range boundaries
+		// All types >= 240 must be rejected
 		assert!(matches!(check_include_type(240), Err(PayerProofError::SignatureTypeNotAllowed)));
 		assert!(matches!(check_include_type(250), Err(PayerProofError::SignatureTypeNotAllowed)));
 		assert!(matches!(check_include_type(1000), Err(PayerProofError::SignatureTypeNotAllowed)));
-		// Just outside the range
+		// Types > 1000 (experimental) must also be rejected
+		assert!(matches!(check_include_type(1001), Err(PayerProofError::SignatureTypeNotAllowed)));
+		assert!(matches!(
+			check_include_type(u64::MAX),
+			Err(PayerProofError::SignatureTypeNotAllowed)
+		));
+		// Just below the boundary
 		assert!(check_include_type(239).is_ok());
-		assert!(check_include_type(1001).is_ok());
 		// Payer metadata still rejected
 		assert!(matches!(check_include_type(0), Err(PayerProofError::InvreqMetadataNotAllowed)));
 	}
@@ -1144,5 +1170,70 @@ mod tests {
 
 		let result = PayerProof::try_from(bytes);
 		assert!(result.is_err(), "Unknown even type 252 should be rejected");
+	}
+
+	/// Test that malformed TLV framing is rejected without panicking.
+	///
+	/// TlvStream::new() panics on malformed BigSize values or out-of-bounds
+	/// lengths. The parser must validate framing before constructing TlvStream.
+	#[test]
+	fn test_parsing_rejects_malformed_tlv_framing() {
+		use core::convert::TryFrom;
+
+		// Truncated BigSize type (0xFD prefix requires 2 more bytes)
+		let result = PayerProof::try_from(vec![0xFD, 0x01]);
+		assert!(result.is_err(), "Truncated BigSize type should be rejected");
+
+		// Valid type but truncated length
+		let result = PayerProof::try_from(vec![0x0a]);
+		assert!(result.is_err(), "Missing length should be rejected");
+
+		// Length exceeds remaining bytes
+		let result = PayerProof::try_from(vec![0x0a, 0x04, 0x00, 0x00]);
+		assert!(result.is_err(), "Length exceeding data should be rejected");
+
+		// Empty input should not panic
+		let result = PayerProof::try_from(vec![]);
+		assert!(result.is_err(), "Empty input should be rejected");
+
+		// Completely invalid bytes
+		let result = PayerProof::try_from(vec![0xFF, 0xFF]);
+		assert!(result.is_err(), "Invalid bytes should be rejected");
+	}
+
+	/// Test that duplicate type-0 TLVs are rejected.
+	///
+	/// Previously the ordering check used `u64` initialized to 0, which
+	/// skipped the check for the first TLV if its type was 0, allowing
+	/// duplicate type-0 records.
+	#[test]
+	fn test_parsing_rejects_duplicate_type_zero() {
+		use core::convert::TryFrom;
+
+		// Two TLV records both with type 0
+		let mut bytes = Vec::new();
+		bytes.extend_from_slice(&[0x00, 0x02, 0x00, 0x00]); // type 0, len 2
+		bytes.extend_from_slice(&[0x00, 0x02, 0x00, 0x00]); // type 0 again (DUPLICATE!)
+
+		let result = PayerProof::try_from(bytes);
+		assert!(result.is_err(), "Duplicate type-0 TLVs should be rejected");
+	}
+
+	/// Test that payer_signature TLV with length < 64 is rejected.
+	///
+	/// The payer_signature value contains a 64-byte schnorr signature
+	/// followed by an optional note. A length < 64 is always invalid.
+	#[test]
+	fn test_parsing_rejects_short_payer_signature() {
+		use core::convert::TryFrom;
+
+		// Craft a TLV with type 250 (payer_signature) but only 32 bytes of value
+		let mut bytes = Vec::new();
+		bytes.push(0xfa); // type 250
+		bytes.push(0x20); // length 32 (too short for 64-byte signature)
+		bytes.extend_from_slice(&[0x00; 32]);
+
+		let result = PayerProof::try_from(bytes);
+		assert!(result.is_err(), "payer_signature with len < 64 should be rejected");
 	}
 }

--- a/lightning/src/offers/payer_proof.rs
+++ b/lightning/src/offers/payer_proof.rs
@@ -35,7 +35,6 @@ use crate::offers::nonce::Nonce;
 use crate::offers::offer::{OFFER_DESCRIPTION_TYPE, OFFER_ISSUER_TYPE};
 use crate::offers::parse::Bech32Encode;
 use crate::offers::payer::PAYER_METADATA_TYPE;
-use crate::types::features::Bolt12InvoiceFeatures;
 use crate::types::payment::{PaymentHash, PaymentPreimage};
 use crate::util::ser::{BigSize, Readable, Writeable};
 
@@ -156,7 +155,15 @@ impl<'a> PayerProofBuilder<'a> {
 		included_types.insert(INVOICE_PAYMENT_HASH_TYPE);
 		included_types.insert(INVOICE_NODE_ID_TYPE);
 
-		if invoice.invoice_features() != &Bolt12InvoiceFeatures::empty() {
+		// Per spec, invoice_features MUST be included "if present" — meaning if the
+		// TLV exists in the invoice byte stream, regardless of whether the parsed
+		// value is empty. Check the raw bytes so we handle invoices from other
+		// implementations that may serialize empty features.
+		let mut invoice_bytes = Vec::new();
+		invoice.write(&mut invoice_bytes).expect("Vec write should not fail");
+		let has_features_tlv =
+			TlvStream::new(&invoice_bytes).any(|r| r.r#type == INVOICE_FEATURES_TYPE);
+		if has_features_tlv {
 			included_types.insert(INVOICE_FEATURES_TYPE);
 		}
 
@@ -224,7 +231,7 @@ impl<'a> PayerProofBuilder<'a> {
 	pub fn build_with_derived_key(
 		self, expanded_key: &ExpandedKey, nonce: Nonce, payment_id: PaymentId, note: Option<&str>,
 	) -> Result<PayerProof, PayerProofError> {
-		let secp_ctx = Secp256k1::new();
+		let secp_ctx = Secp256k1::signing_only();
 		let keys = self
 			.invoice
 			.derive_payer_signing_keys(payment_id, nonce, expanded_key, &secp_ctx)

--- a/lightning/src/offers/payer_proof.rs
+++ b/lightning/src/offers/payer_proof.rs
@@ -168,13 +168,13 @@ impl<'a> PayerProofBuilder<'a> {
 	/// Include a specific TLV type in the proof.
 	///
 	/// Returns an error if the type is not allowed (e.g., invreq_metadata or
-	/// types >= 240 which are in the signature/payer-proof range and handled
-	/// separately).
+	/// types in the signature/payer-proof range (240..=1000), which are handled
+	/// separately.
 	pub fn include_type(mut self, tlv_type: u64) -> Result<Self, PayerProofError> {
 		if tlv_type == PAYER_METADATA_TYPE {
 			return Err(PayerProofError::InvreqMetadataNotAllowed);
 		}
-		if tlv_type >= TLV_SIGNATURE {
+		if SIGNATURE_TYPES.contains(&tlv_type) {
 			return Err(PayerProofError::SignatureTypeNotAllowed);
 		}
 		self.included_types.insert(tlv_type);
@@ -327,11 +327,11 @@ impl UnsignedPayerProof {
 	fn serialize_payer_proof(&self, payer_signature: &Signature, note: Option<&str>) -> Vec<u8> {
 		let mut bytes = Vec::new();
 
-		// Filter out SIGNATURE_TYPES defensively: the invoice bytes contain the
-		// invoice's own signature (type 240) which must not appear as an included
-		// invoice record — the payer proof writes its own signature TLV below.
+		// Preserve TLV ordering by emitting included invoice records below the
+		// payer-proof range first, then payer-proof TLVs (240..=250), then any
+		// disclosed experimental invoice records above the reserved range.
 		for record in TlvStream::new(&self.invoice_bytes).filter(|r| {
-			self.included_types.contains(&r.r#type) && !SIGNATURE_TYPES.contains(&r.r#type)
+			self.included_types.contains(&r.r#type) && r.r#type < TLV_SIGNATURE
 		}) {
 			bytes.extend_from_slice(record.record_bytes);
 		}
@@ -382,6 +382,14 @@ impl UnsignedPayerProof {
 		BigSize(payer_sig_len as u64).write(&mut bytes).expect("Vec write should not fail");
 		payer_signature.write(&mut bytes).expect("Vec write should not fail");
 		bytes.extend_from_slice(note_bytes);
+
+		for record in TlvStream::new(&self.invoice_bytes).filter(|r| {
+			self.included_types.contains(&r.r#type)
+				&& !SIGNATURE_TYPES.contains(&r.r#type)
+				&& r.r#type > *SIGNATURE_TYPES.end()
+		}) {
+			bytes.extend_from_slice(record.record_bytes);
+		}
 
 		bytes
 	}
@@ -592,7 +600,7 @@ impl TryFrom<Vec<u8>> for PayerProof {
 					if tlv_type == PAYER_METADATA_TYPE {
 						return Err(Bolt12ParseError::Decode(DecodeError::InvalidValue));
 					}
-					if tlv_type < TLV_SIGNATURE {
+					if !SIGNATURE_TYPES.contains(&tlv_type) {
 						// Included invoice TLV record (passthrough for merkle
 						// reconstruction).
 						included_types.insert(tlv_type);

--- a/lightning/src/offers/payer_proof.rs
+++ b/lightning/src/offers/payer_proof.rs
@@ -1,0 +1,1064 @@
+// This file is Copyright its original authors, visible in version control
+// history.
+//
+// This file is licensed under the Apache License, Version 2.0 <LICENSE-APACHE
+// or http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your option.
+// You may not use this file except in accordance with one or both of these
+// licenses.
+
+//! Payer proofs for BOLT 12 invoices.
+//!
+//! A [`PayerProof`] cryptographically proves that a BOLT 12 invoice was paid by demonstrating:
+//! - Possession of the payment preimage (proving the payment occurred)
+//! - A valid invoice signature over a merkle root (proving the invoice is authentic)
+//! - The payer's signature (proving who authorized the payment)
+//!
+//! This implements the payer proof extension to BOLT 12 as specified in
+//! <https://github.com/lightning/bolts/pull/1295>.
+
+use alloc::collections::BTreeSet;
+
+use crate::io;
+use crate::io::Read;
+use crate::ln::channelmanager::PaymentId;
+use crate::ln::inbound_payment::ExpandedKey;
+use crate::offers::invoice::{
+	Bolt12Invoice, INVOICE_AMOUNT_TYPE, INVOICE_CREATED_AT_TYPE, INVOICE_FEATURES_TYPE,
+	INVOICE_NODE_ID_TYPE, INVOICE_PAYMENT_HASH_TYPE, SIGNATURE_TAG,
+};
+use crate::offers::invoice_request::INVOICE_REQUEST_PAYER_ID_TYPE;
+use crate::offers::merkle::{
+	self, SelectiveDisclosure, SelectiveDisclosureError, TaggedHash, TlvStream, SIGNATURE_TYPES,
+};
+use crate::offers::nonce::Nonce;
+use crate::offers::offer::{OFFER_DESCRIPTION_TYPE, OFFER_ISSUER_TYPE};
+use crate::offers::parse::Bech32Encode;
+use crate::offers::payer::PAYER_METADATA_TYPE;
+use crate::types::features::Bolt12InvoiceFeatures;
+use crate::types::payment::{PaymentHash, PaymentPreimage};
+use crate::util::ser::{BigSize, Readable, Writeable};
+
+use bitcoin::hashes::{sha256, Hash, HashEngine};
+use bitcoin::secp256k1::schnorr::Signature;
+use bitcoin::secp256k1::{Message, PublicKey, Secp256k1};
+
+use core::convert::TryFrom;
+
+#[allow(unused_imports)]
+use crate::prelude::*;
+
+const TLV_SIGNATURE: u64 = 240;
+const TLV_PREIMAGE: u64 = 242;
+const TLV_OMITTED_TLVS: u64 = 244;
+const TLV_MISSING_HASHES: u64 = 246;
+const TLV_LEAF_HASHES: u64 = 248;
+const TLV_PAYER_SIGNATURE: u64 = 250;
+
+/// Human-readable prefix for payer proofs in bech32 encoding.
+pub const PAYER_PROOF_HRP: &str = "lnp";
+
+/// Tag for payer signature computation per BOLT 12 signature calculation.
+/// Format: "lightning" || messagename || fieldname
+const PAYER_SIGNATURE_TAG: &str = concat!("lightning", "payer_proof", "payer_signature");
+
+/// Error when building or verifying a payer proof.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PayerProofError {
+	/// The preimage doesn't match the invoice's payment hash.
+	PreimageMismatch,
+	/// Error during merkle tree operations.
+	MerkleError(SelectiveDisclosureError),
+	/// The invoice signature is invalid.
+	InvalidInvoiceSignature,
+	/// The payer signature is invalid.
+	InvalidPayerSignature,
+	/// Failed to re-derive the payer signing key from the provided nonce and payment ID.
+	KeyDerivationFailed,
+	/// Error during signing.
+	SigningError,
+	/// Missing required field in the proof.
+	MissingRequiredField(&'static str),
+	/// The proof contains invalid data.
+	InvalidData(&'static str),
+	/// The invreq_metadata field cannot be included (per spec).
+	InvreqMetadataNotAllowed,
+	/// The omitted_markers contains an included TLV type.
+	OmittedMarkersContainIncluded,
+	/// The omitted_markers has too many trailing markers.
+	TooManyTrailingOmittedMarkers,
+	/// Error decoding the payer proof.
+	DecodeError(crate::ln::msgs::DecodeError),
+}
+
+impl From<SelectiveDisclosureError> for PayerProofError {
+	fn from(e: SelectiveDisclosureError) -> Self {
+		PayerProofError::MerkleError(e)
+	}
+}
+
+impl From<crate::ln::msgs::DecodeError> for PayerProofError {
+	fn from(e: crate::ln::msgs::DecodeError) -> Self {
+		PayerProofError::DecodeError(e)
+	}
+}
+
+/// A cryptographic proof that a BOLT 12 invoice was paid.
+///
+/// Contains the payment preimage, selective disclosure of invoice fields,
+/// the invoice signature, and a payer signature proving who paid.
+#[derive(Clone, Debug)]
+pub struct PayerProof {
+	bytes: Vec<u8>,
+	contents: PayerProofContents,
+	merkle_root: sha256::Hash,
+}
+
+#[derive(Clone, Debug)]
+struct PayerProofContents {
+	payer_id: PublicKey,
+	payment_hash: PaymentHash,
+	issuer_signing_pubkey: PublicKey,
+	preimage: PaymentPreimage,
+	invoice_signature: Signature,
+	payer_signature: Signature,
+	payer_note: Option<String>,
+}
+
+/// Builds a [`PayerProof`] from a paid invoice and its preimage.
+///
+/// By default, only the required fields are included (payer_id, payment_hash,
+/// issuer_signing_pubkey). Additional fields can be included for selective disclosure
+/// using the `include_*` methods.
+pub struct PayerProofBuilder<'a> {
+	invoice: &'a Bolt12Invoice,
+	preimage: PaymentPreimage,
+	included_types: BTreeSet<u64>,
+}
+
+impl<'a> PayerProofBuilder<'a> {
+	/// Create a new builder from a paid invoice and its preimage.
+	///
+	/// Returns an error if the preimage doesn't match the invoice's payment hash.
+	pub(super) fn new(
+		invoice: &'a Bolt12Invoice, preimage: PaymentPreimage,
+	) -> Result<Self, PayerProofError> {
+		let computed_hash = sha256::Hash::hash(&preimage.0);
+		if computed_hash.as_byte_array() != &invoice.payment_hash().0 {
+			return Err(PayerProofError::PreimageMismatch);
+		}
+
+		let mut included_types = BTreeSet::new();
+		included_types.insert(INVOICE_REQUEST_PAYER_ID_TYPE);
+		included_types.insert(INVOICE_PAYMENT_HASH_TYPE);
+		included_types.insert(INVOICE_NODE_ID_TYPE);
+
+		if invoice.invoice_features() != &Bolt12InvoiceFeatures::empty() {
+			included_types.insert(INVOICE_FEATURES_TYPE);
+		}
+
+		Ok(Self { invoice, preimage, included_types })
+	}
+
+	/// Include a specific TLV type in the proof.
+	///
+	/// Returns an error if the type is not allowed (e.g., invreq_metadata).
+	pub fn include_type(mut self, tlv_type: u64) -> Result<Self, PayerProofError> {
+		if tlv_type == PAYER_METADATA_TYPE {
+			return Err(PayerProofError::InvreqMetadataNotAllowed);
+		}
+		self.included_types.insert(tlv_type);
+		Ok(self)
+	}
+
+	/// Include the offer description in the proof.
+	pub fn include_offer_description(mut self) -> Self {
+		self.included_types.insert(OFFER_DESCRIPTION_TYPE);
+		self
+	}
+
+	/// Include the offer issuer in the proof.
+	pub fn include_offer_issuer(mut self) -> Self {
+		self.included_types.insert(OFFER_ISSUER_TYPE);
+		self
+	}
+
+	/// Include the invoice amount in the proof.
+	pub fn include_invoice_amount(mut self) -> Self {
+		self.included_types.insert(INVOICE_AMOUNT_TYPE);
+		self
+	}
+
+	/// Include the invoice creation timestamp in the proof.
+	pub fn include_invoice_created_at(mut self) -> Self {
+		self.included_types.insert(INVOICE_CREATED_AT_TYPE);
+		self
+	}
+
+	/// Builds a signed [`PayerProof`] using the provided signing function.
+	///
+	/// Use this when you have direct access to the payer's signing key.
+	pub fn build<F>(self, sign_fn: F, note: Option<&str>) -> Result<PayerProof, PayerProofError>
+	where
+		F: FnOnce(&Message) -> Result<Signature, ()>,
+	{
+		let unsigned = self.build_unsigned()?;
+		unsigned.sign(sign_fn, note)
+	}
+
+	/// Builds a signed [`PayerProof`] using a key derived from an [`ExpandedKey`] and [`Nonce`].
+	///
+	/// This re-derives the payer signing key using the same derivation scheme as invoice requests
+	/// created with `deriving_signing_pubkey`. The `nonce` and `payment_id` must be the same ones
+	/// used when creating the original invoice request (available from the
+	/// [`OffersContext::OutboundPaymentForOffer`]).
+	///
+	/// [`OffersContext::OutboundPaymentForOffer`]: crate::blinded_path::message::OffersContext::OutboundPaymentForOffer
+	pub fn build_with_derived_key(
+		self, expanded_key: &ExpandedKey, nonce: Nonce, payment_id: PaymentId, note: Option<&str>,
+	) -> Result<PayerProof, PayerProofError> {
+		let secp_ctx = Secp256k1::new();
+		let keys = self
+			.invoice
+			.derive_payer_signing_keys(payment_id, nonce, expanded_key, &secp_ctx)
+			.map_err(|_| PayerProofError::KeyDerivationFailed)?;
+
+		let unsigned = self.build_unsigned()?;
+		unsigned.sign(|message| Ok(secp_ctx.sign_schnorr_no_aux_rand(message, &keys)), note)
+	}
+
+	fn build_unsigned(self) -> Result<UnsignedPayerProof, PayerProofError> {
+		let mut invoice_bytes = Vec::new();
+		self.invoice.write(&mut invoice_bytes).expect("Vec write should not fail");
+		let mut bytes_without_sig = Vec::with_capacity(invoice_bytes.len());
+		for r in TlvStream::new(&invoice_bytes).filter(|r| !SIGNATURE_TYPES.contains(&r.r#type)) {
+			bytes_without_sig.extend_from_slice(r.record_bytes);
+		}
+
+		let disclosure =
+			merkle::compute_selective_disclosure(&bytes_without_sig, &self.included_types)?;
+
+		let invoice_signature = self.invoice.signature();
+
+		Ok(UnsignedPayerProof {
+			invoice_signature,
+			preimage: self.preimage,
+			payer_id: self.invoice.payer_signing_pubkey(),
+			payment_hash: self.invoice.payment_hash().clone(),
+			issuer_signing_pubkey: self.invoice.signing_pubkey(),
+			invoice_bytes,
+			included_types: self.included_types,
+			disclosure,
+		})
+	}
+}
+
+/// An unsigned [`PayerProof`] ready for signing.
+struct UnsignedPayerProof {
+	invoice_signature: Signature,
+	preimage: PaymentPreimage,
+	payer_id: PublicKey,
+	payment_hash: PaymentHash,
+	issuer_signing_pubkey: PublicKey,
+	invoice_bytes: Vec<u8>,
+	included_types: BTreeSet<u64>,
+	disclosure: SelectiveDisclosure,
+}
+
+impl UnsignedPayerProof {
+	fn sign<F>(self, sign_fn: F, note: Option<&str>) -> Result<PayerProof, PayerProofError>
+	where
+		F: FnOnce(&Message) -> Result<Signature, ()>,
+	{
+		let message = Self::compute_payer_signature_message(note, &self.disclosure.merkle_root);
+		let payer_signature = sign_fn(&message).map_err(|_| PayerProofError::SigningError)?;
+
+		let secp_ctx = Secp256k1::verification_only();
+		secp_ctx
+			.verify_schnorr(&payer_signature, &message, &self.payer_id.into())
+			.map_err(|_| PayerProofError::InvalidPayerSignature)?;
+
+		let bytes = self.serialize_payer_proof(&payer_signature, note);
+
+		Ok(PayerProof {
+			bytes,
+			contents: PayerProofContents {
+				payer_id: self.payer_id,
+				payment_hash: self.payment_hash,
+				issuer_signing_pubkey: self.issuer_signing_pubkey,
+				preimage: self.preimage,
+				invoice_signature: self.invoice_signature,
+				payer_signature,
+				payer_note: note.map(String::from),
+			},
+			merkle_root: self.disclosure.merkle_root,
+		})
+	}
+
+	/// Compute the payer signature message per BOLT 12 signature calculation.
+	fn compute_payer_signature_message(note: Option<&str>, merkle_root: &sha256::Hash) -> Message {
+		let mut inner_hasher = sha256::Hash::engine();
+		if let Some(n) = note {
+			inner_hasher.input(n.as_bytes());
+		}
+		inner_hasher.input(merkle_root.as_ref());
+		let inner_msg = sha256::Hash::from_engine(inner_hasher);
+
+		let tag_hash = sha256::Hash::hash(PAYER_SIGNATURE_TAG.as_bytes());
+
+		let mut final_hasher = sha256::Hash::engine();
+		final_hasher.input(tag_hash.as_ref());
+		final_hasher.input(tag_hash.as_ref());
+		final_hasher.input(inner_msg.as_ref());
+		let final_digest = sha256::Hash::from_engine(final_hasher);
+
+		Message::from_digest(*final_digest.as_byte_array())
+	}
+
+	fn serialize_payer_proof(&self, payer_signature: &Signature, note: Option<&str>) -> Vec<u8> {
+		let mut bytes = Vec::new();
+
+		for record in
+			TlvStream::new(&self.invoice_bytes).filter(|r| self.included_types.contains(&r.r#type))
+		{
+			bytes.extend_from_slice(record.record_bytes);
+		}
+
+		BigSize(TLV_SIGNATURE).write(&mut bytes).expect("Vec write should not fail");
+		BigSize(64).write(&mut bytes).expect("Vec write should not fail");
+		self.invoice_signature.write(&mut bytes).expect("Vec write should not fail");
+
+		BigSize(TLV_PREIMAGE).write(&mut bytes).expect("Vec write should not fail");
+		BigSize(32).write(&mut bytes).expect("Vec write should not fail");
+		bytes.extend_from_slice(&self.preimage.0);
+
+		if !self.disclosure.omitted_markers.is_empty() {
+			let omitted_len: u64 = self
+				.disclosure
+				.omitted_markers
+				.iter()
+				.map(|m| BigSize(*m).serialized_length() as u64)
+				.sum();
+			BigSize(TLV_OMITTED_TLVS).write(&mut bytes).expect("Vec write should not fail");
+			BigSize(omitted_len).write(&mut bytes).expect("Vec write should not fail");
+			for marker in &self.disclosure.omitted_markers {
+				BigSize(*marker).write(&mut bytes).expect("Vec write should not fail");
+			}
+		}
+
+		if !self.disclosure.missing_hashes.is_empty() {
+			let len = self.disclosure.missing_hashes.len() * 32;
+			BigSize(TLV_MISSING_HASHES).write(&mut bytes).expect("Vec write should not fail");
+			BigSize(len as u64).write(&mut bytes).expect("Vec write should not fail");
+			for hash in &self.disclosure.missing_hashes {
+				bytes.extend_from_slice(hash.as_ref());
+			}
+		}
+
+		if !self.disclosure.leaf_hashes.is_empty() {
+			let len = self.disclosure.leaf_hashes.len() * 32;
+			BigSize(TLV_LEAF_HASHES).write(&mut bytes).expect("Vec write should not fail");
+			BigSize(len as u64).write(&mut bytes).expect("Vec write should not fail");
+			for hash in &self.disclosure.leaf_hashes {
+				bytes.extend_from_slice(hash.as_ref());
+			}
+		}
+
+		let note_bytes = note.map(|n| n.as_bytes()).unwrap_or(&[]);
+		let payer_sig_len = 64 + note_bytes.len();
+		BigSize(TLV_PAYER_SIGNATURE).write(&mut bytes).expect("Vec write should not fail");
+		BigSize(payer_sig_len as u64).write(&mut bytes).expect("Vec write should not fail");
+		payer_signature.write(&mut bytes).expect("Vec write should not fail");
+		bytes.extend_from_slice(note_bytes);
+
+		bytes
+	}
+}
+
+impl PayerProof {
+	/// The payment preimage proving the invoice was paid.
+	pub fn preimage(&self) -> PaymentPreimage {
+		self.contents.preimage
+	}
+
+	/// The payer's public key (who paid).
+	pub fn payer_id(&self) -> PublicKey {
+		self.contents.payer_id
+	}
+
+	/// The issuer's signing public key (the key that signed the invoice).
+	pub fn issuer_signing_pubkey(&self) -> PublicKey {
+		self.contents.issuer_signing_pubkey
+	}
+
+	/// The payment hash.
+	pub fn payment_hash(&self) -> PaymentHash {
+		self.contents.payment_hash
+	}
+
+	/// The invoice signature over the merkle root.
+	pub fn invoice_signature(&self) -> Signature {
+		self.contents.invoice_signature
+	}
+
+	/// The payer's schnorr signature proving who authorized the payment.
+	pub fn payer_signature(&self) -> Signature {
+		self.contents.payer_signature
+	}
+
+	/// The payer's note, if any.
+	pub fn payer_note(&self) -> Option<&str> {
+		self.contents.payer_note.as_deref()
+	}
+
+	/// The merkle root of the original invoice.
+	pub fn merkle_root(&self) -> sha256::Hash {
+		self.merkle_root
+	}
+
+	/// The raw bytes of the payer proof.
+	pub fn bytes(&self) -> &[u8] {
+		&self.bytes
+	}
+}
+
+impl Bech32Encode for PayerProof {
+	const BECH32_HRP: &'static str = PAYER_PROOF_HRP;
+}
+
+impl AsRef<[u8]> for PayerProof {
+	fn as_ref(&self) -> &[u8] {
+		&self.bytes
+	}
+}
+
+/// Read a value from a TLV record's raw bytes, skipping the type and length
+/// prefix.
+fn read_tlv_value<T: Readable>(record_bytes: &[u8]) -> Result<T, crate::ln::msgs::DecodeError> {
+	let mut cursor = io::Cursor::new(record_bytes);
+	let _type: BigSize = Readable::read(&mut cursor)?;
+	let _len: BigSize = Readable::read(&mut cursor)?;
+	Readable::read(&mut cursor)
+}
+
+// Payer proofs use manual TLV parsing rather than `ParsedMessage` / `tlv_stream!`
+// because of their hybrid structure: a dynamic, variable set of included invoice
+// TLV records (types 0-239, preserved as raw bytes for merkle reconstruction) plus
+// payer-proof-specific TLVs (types 240-250) with non-standard encodings such as
+// BigSize lists (`omitted_tlvs`) and concatenated 32-byte hashes
+// (`missing_hashes`, `leaf_hashes`). The `tlv_stream!` macro assumes a fixed set
+// of known fields with standard `Readable`/`Writeable` encodings, so it cannot
+// express the passthrough-or-parse logic required here.
+impl TryFrom<Vec<u8>> for PayerProof {
+	type Error = crate::offers::parse::Bolt12ParseError;
+
+	fn try_from(bytes: Vec<u8>) -> Result<Self, Self::Error> {
+		use crate::ln::msgs::DecodeError;
+		use crate::offers::parse::Bolt12ParseError;
+
+		let mut payer_id: Option<PublicKey> = None;
+		let mut payment_hash: Option<PaymentHash> = None;
+		let mut issuer_signing_pubkey: Option<PublicKey> = None;
+		let mut invoice_signature: Option<Signature> = None;
+		let mut preimage: Option<PaymentPreimage> = None;
+		let mut payer_signature: Option<Signature> = None;
+		let mut payer_note: Option<String> = None;
+
+		let mut leaf_hashes: Vec<sha256::Hash> = Vec::new();
+		let mut omitted_markers: Vec<u64> = Vec::new();
+		let mut missing_hashes: Vec<sha256::Hash> = Vec::new();
+
+		let mut included_types: BTreeSet<u64> = BTreeSet::new();
+		let mut included_records: Vec<(u64, usize, usize)> = Vec::new();
+
+		let mut prev_tlv_type: u64 = 0;
+
+		for record in TlvStream::new(&bytes) {
+			let tlv_type = record.r#type;
+
+			// Strict ascending order check covers both ordering and duplicates.
+			if tlv_type <= prev_tlv_type && prev_tlv_type != 0 {
+				return Err(Bolt12ParseError::Decode(DecodeError::InvalidValue));
+			}
+			prev_tlv_type = tlv_type;
+
+			match tlv_type {
+				INVOICE_REQUEST_PAYER_ID_TYPE => {
+					payer_id = Some(read_tlv_value(record.record_bytes)?);
+					included_types.insert(tlv_type);
+					included_records.push((
+						tlv_type,
+						record.end - record.record_bytes.len(),
+						record.end,
+					));
+				},
+				INVOICE_PAYMENT_HASH_TYPE => {
+					payment_hash = Some(read_tlv_value(record.record_bytes)?);
+					included_types.insert(tlv_type);
+					included_records.push((
+						tlv_type,
+						record.end - record.record_bytes.len(),
+						record.end,
+					));
+				},
+				INVOICE_NODE_ID_TYPE => {
+					issuer_signing_pubkey = Some(read_tlv_value(record.record_bytes)?);
+					included_types.insert(tlv_type);
+					included_records.push((
+						tlv_type,
+						record.end - record.record_bytes.len(),
+						record.end,
+					));
+				},
+				TLV_SIGNATURE => {
+					let mut record_cursor = io::Cursor::new(record.record_bytes);
+					let _type: BigSize = Readable::read(&mut record_cursor)?;
+					let _len: BigSize = Readable::read(&mut record_cursor)?;
+					invoice_signature = Some(Readable::read(&mut record_cursor)?);
+				},
+				TLV_PREIMAGE => {
+					let mut record_cursor = io::Cursor::new(record.record_bytes);
+					let _type: BigSize = Readable::read(&mut record_cursor)?;
+					let _len: BigSize = Readable::read(&mut record_cursor)?;
+					let mut preimage_bytes = [0u8; 32];
+					record_cursor
+						.read_exact(&mut preimage_bytes)
+						.map_err(|_| DecodeError::ShortRead)?;
+					preimage = Some(PaymentPreimage(preimage_bytes));
+				},
+				TLV_OMITTED_TLVS => {
+					let mut record_cursor = io::Cursor::new(record.record_bytes);
+					let _type: BigSize = Readable::read(&mut record_cursor)?;
+					let len: BigSize = Readable::read(&mut record_cursor)?;
+					let end_pos = record_cursor.position() + len.0;
+					while record_cursor.position() < end_pos {
+						let marker: BigSize = Readable::read(&mut record_cursor)?;
+						omitted_markers.push(marker.0);
+					}
+				},
+				TLV_MISSING_HASHES => {
+					let mut record_cursor = io::Cursor::new(record.record_bytes);
+					let _type: BigSize = Readable::read(&mut record_cursor)?;
+					let len: BigSize = Readable::read(&mut record_cursor)?;
+					if len.0 % 32 != 0 {
+						return Err(Bolt12ParseError::Decode(DecodeError::InvalidValue));
+					}
+					let num_hashes = len.0 / 32;
+					for _ in 0..num_hashes {
+						let mut hash_bytes = [0u8; 32];
+						record_cursor
+							.read_exact(&mut hash_bytes)
+							.map_err(|_| DecodeError::ShortRead)?;
+						missing_hashes.push(sha256::Hash::from_byte_array(hash_bytes));
+					}
+				},
+				TLV_LEAF_HASHES => {
+					let mut record_cursor = io::Cursor::new(record.record_bytes);
+					let _type: BigSize = Readable::read(&mut record_cursor)?;
+					let len: BigSize = Readable::read(&mut record_cursor)?;
+					if len.0 % 32 != 0 {
+						return Err(Bolt12ParseError::Decode(DecodeError::InvalidValue));
+					}
+					let num_hashes = len.0 / 32;
+					for _ in 0..num_hashes {
+						let mut hash_bytes = [0u8; 32];
+						record_cursor
+							.read_exact(&mut hash_bytes)
+							.map_err(|_| DecodeError::ShortRead)?;
+						leaf_hashes.push(sha256::Hash::from_byte_array(hash_bytes));
+					}
+				},
+				TLV_PAYER_SIGNATURE => {
+					let mut record_cursor = io::Cursor::new(record.record_bytes);
+					let _type: BigSize = Readable::read(&mut record_cursor)?;
+					let len: BigSize = Readable::read(&mut record_cursor)?;
+					payer_signature = Some(Readable::read(&mut record_cursor)?);
+					let note_len = len.0.saturating_sub(64);
+					if note_len > 0 {
+						let mut note_bytes = vec![0u8; note_len as usize];
+						record_cursor
+							.read_exact(&mut note_bytes)
+							.map_err(|_| DecodeError::ShortRead)?;
+						payer_note = Some(
+							String::from_utf8(note_bytes).map_err(|_| DecodeError::InvalidValue)?,
+						);
+					}
+				},
+				_ => {
+					if tlv_type == PAYER_METADATA_TYPE {
+						return Err(Bolt12ParseError::Decode(DecodeError::InvalidValue));
+					}
+					if tlv_type < TLV_SIGNATURE {
+						// Included invoice TLV record (passthrough for merkle
+						// reconstruction).
+						included_types.insert(tlv_type);
+						included_records.push((
+							tlv_type,
+							record.end - record.record_bytes.len(),
+							record.end,
+						));
+					} else if tlv_type % 2 == 0 {
+						// Unknown even types are mandatory-to-understand per
+						// BOLT convention — reject them.
+						return Err(Bolt12ParseError::Decode(DecodeError::InvalidValue));
+					}
+					// Unknown odd types can be safely ignored.
+				},
+			}
+		}
+
+		let payer_id = payer_id.ok_or(Bolt12ParseError::InvalidSemantics(
+			crate::offers::parse::Bolt12SemanticError::MissingPayerSigningPubkey,
+		))?;
+		let payment_hash = payment_hash.ok_or(Bolt12ParseError::InvalidSemantics(
+			crate::offers::parse::Bolt12SemanticError::MissingPaymentHash,
+		))?;
+		let issuer_signing_pubkey =
+			issuer_signing_pubkey.ok_or(Bolt12ParseError::InvalidSemantics(
+				crate::offers::parse::Bolt12SemanticError::MissingSigningPubkey,
+			))?;
+		let invoice_signature = invoice_signature.ok_or(Bolt12ParseError::InvalidSemantics(
+			crate::offers::parse::Bolt12SemanticError::MissingSignature,
+		))?;
+		let preimage = preimage.ok_or(Bolt12ParseError::Decode(DecodeError::InvalidValue))?;
+		let payer_signature = payer_signature.ok_or(Bolt12ParseError::InvalidSemantics(
+			crate::offers::parse::Bolt12SemanticError::MissingSignature,
+		))?;
+
+		validate_omitted_markers_for_parsing(&omitted_markers, &included_types)
+			.map_err(|_| Bolt12ParseError::Decode(DecodeError::InvalidValue))?;
+
+		if leaf_hashes.len() != included_records.len() {
+			return Err(Bolt12ParseError::Decode(DecodeError::InvalidValue));
+		}
+
+		let included_refs: Vec<(u64, &[u8])> =
+			included_records.iter().map(|&(t, start, end)| (t, &bytes[start..end])).collect();
+		let merkle_root = merkle::reconstruct_merkle_root(
+			&included_refs,
+			&leaf_hashes,
+			&omitted_markers,
+			&missing_hashes,
+		)
+		.map_err(|_| Bolt12ParseError::Decode(DecodeError::InvalidValue))?;
+
+		// Verify preimage matches payment hash.
+		let computed = sha256::Hash::hash(&preimage.0);
+		if computed.as_byte_array() != &payment_hash.0 {
+			return Err(Bolt12ParseError::Decode(DecodeError::InvalidValue));
+		}
+
+		// Verify the invoice signature against the issuer signing pubkey.
+		let tagged_hash = TaggedHash::from_merkle_root(SIGNATURE_TAG, merkle_root);
+		merkle::verify_signature(&invoice_signature, &tagged_hash, issuer_signing_pubkey)
+			.map_err(|_| Bolt12ParseError::Decode(DecodeError::InvalidValue))?;
+
+		// Verify the payer signature.
+		let message = UnsignedPayerProof::compute_payer_signature_message(
+			payer_note.as_deref(),
+			&merkle_root,
+		);
+		let secp_ctx = Secp256k1::verification_only();
+		secp_ctx
+			.verify_schnorr(&payer_signature, &message, &payer_id.into())
+			.map_err(|_| Bolt12ParseError::Decode(DecodeError::InvalidValue))?;
+
+		Ok(PayerProof {
+			bytes,
+			contents: PayerProofContents {
+				payer_id,
+				payment_hash,
+				issuer_signing_pubkey,
+				preimage,
+				invoice_signature,
+				payer_signature,
+				payer_note,
+			},
+			merkle_root,
+		})
+	}
+}
+
+/// Validate omitted markers during parsing.
+///
+/// Per spec:
+/// - MUST NOT contain 0
+/// - MUST NOT contain signature TLV element numbers (240-1000)
+/// - MUST be in strict ascending order
+/// - MUST NOT contain the number of an included TLV field
+/// - MUST NOT contain more than one number larger than the largest included non-signature TLV
+/// - Markers MUST be minimized: each marker must be exactly prev_value + 1 within
+///   a run, and the first marker after an included type X must be X + 1
+fn validate_omitted_markers_for_parsing(
+	omitted_markers: &[u64], included_types: &BTreeSet<u64>,
+) -> Result<(), PayerProofError> {
+	let mut inc_iter = included_types.iter().copied().peekable();
+	// After implicit TLV0 (marker 0), the first minimized marker would be 1
+	let mut expected_next: u64 = 1;
+	let mut trailing_count = 0;
+	let max_included = included_types.iter().copied().max().unwrap_or(0);
+	let mut prev = 0u64;
+
+	for &marker in omitted_markers {
+		// MUST NOT contain 0
+		if marker == 0 {
+			return Err(PayerProofError::InvalidData("omitted_markers contains 0"));
+		}
+
+		// MUST NOT contain signature TLV types
+		if SIGNATURE_TYPES.contains(&marker) {
+			return Err(PayerProofError::InvalidData("omitted_markers contains signature type"));
+		}
+
+		// MUST be strictly ascending
+		if marker <= prev {
+			return Err(PayerProofError::InvalidData("omitted_markers not strictly ascending"));
+		}
+
+		// MUST NOT contain included TLV types
+		if included_types.contains(&marker) {
+			return Err(PayerProofError::OmittedMarkersContainIncluded);
+		}
+
+		// Validate minimization: marker must equal expected_next (continuation
+		// of current run), or there must be an included type X between the
+		// previous position and this marker such that X + 1 == marker.
+		if marker != expected_next {
+			let mut found = false;
+			for inc_type in inc_iter.by_ref() {
+				if inc_type + 1 == marker {
+					found = true;
+					break;
+				}
+				if inc_type >= marker {
+					return Err(PayerProofError::InvalidData("omitted_markers not minimized"));
+				}
+			}
+			if !found {
+				return Err(PayerProofError::InvalidData("omitted_markers not minimized"));
+			}
+		}
+
+		expected_next = marker + 1;
+
+		// Count markers larger than largest included
+		if marker > max_included {
+			trailing_count += 1;
+		}
+
+		prev = marker;
+	}
+
+	// MUST NOT contain more than one number larger than largest included
+	if trailing_count > 1 {
+		return Err(PayerProofError::TooManyTrailingOmittedMarkers);
+	}
+
+	Ok(())
+}
+
+impl core::fmt::Display for PayerProof {
+	fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+		self.fmt_bech32_str(f)
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::offers::merkle::compute_selective_disclosure;
+
+	#[test]
+	fn test_selective_disclosure_computation() {
+		// Test that the merkle selective disclosure works correctly
+		// Simple TLV stream with types 1, 2
+		let tlv_bytes = vec![
+			0x01, 0x03, 0xe8, 0x03, 0xe8, // type 1, length 3, value
+			0x02, 0x08, 0x00, 0x00, 0x01, 0x00, 0x00, 0x02, 0x00, 0x03, // type 2
+		];
+
+		let mut included = BTreeSet::new();
+		included.insert(1);
+
+		let result = compute_selective_disclosure(&tlv_bytes, &included);
+		assert!(result.is_ok());
+
+		let disclosure = result.unwrap();
+		assert_eq!(disclosure.leaf_hashes.len(), 1); // One included TLV
+		assert!(!disclosure.missing_hashes.is_empty()); // Should have missing hashes for omitted
+	}
+
+	/// Test the omitted_markers marker algorithm per BOLT 12 payer proof spec.
+	///
+	/// From the spec example:
+	/// TLVs: 0 (omitted), 10 (included), 20 (omitted), 30 (omitted),
+	///       40 (included), 50 (omitted), 60 (omitted), 240 (signature)
+	///
+	/// Expected markers: [11, 12, 41, 42]
+	///
+	/// The algorithm:
+	/// - TLV 0 is always omitted and implicit (not in markers)
+	/// - For omitted TLV after included: marker = prev_included_type + 1
+	/// - For consecutive omitted TLVs: marker = prev_marker + 1
+	#[test]
+	fn test_omitted_markers_spec_example() {
+		// Build a synthetic TLV stream matching the spec example
+		// TLV format: type (BigSize) || length (BigSize) || value
+		let mut tlv_bytes = Vec::new();
+
+		// TLV 0: type=0, len=4, value=dummy
+		tlv_bytes.extend_from_slice(&[0x00, 0x04, 0x00, 0x00, 0x00, 0x00]);
+		// TLV 10: type=10, len=2, value=dummy
+		tlv_bytes.extend_from_slice(&[0x0a, 0x02, 0x00, 0x00]);
+		// TLV 20: type=20, len=2, value=dummy
+		tlv_bytes.extend_from_slice(&[0x14, 0x02, 0x00, 0x00]);
+		// TLV 30: type=30, len=2, value=dummy
+		tlv_bytes.extend_from_slice(&[0x1e, 0x02, 0x00, 0x00]);
+		// TLV 40: type=40, len=2, value=dummy
+		tlv_bytes.extend_from_slice(&[0x28, 0x02, 0x00, 0x00]);
+		// TLV 50: type=50, len=2, value=dummy
+		tlv_bytes.extend_from_slice(&[0x32, 0x02, 0x00, 0x00]);
+		// TLV 60: type=60, len=2, value=dummy
+		tlv_bytes.extend_from_slice(&[0x3c, 0x02, 0x00, 0x00]);
+
+		// Include types 10 and 40
+		let mut included = BTreeSet::new();
+		included.insert(10);
+		included.insert(40);
+
+		let disclosure = compute_selective_disclosure(&tlv_bytes, &included).unwrap();
+
+		// Per spec example, omitted_markers should be [11, 12, 41, 42]
+		assert_eq!(disclosure.omitted_markers, vec![11, 12, 41, 42]);
+
+		// leaf_hashes should have 2 entries (one for each included TLV)
+		assert_eq!(disclosure.leaf_hashes.len(), 2);
+	}
+
+	/// Test that the marker algorithm handles edge cases correctly.
+	#[test]
+	fn test_omitted_markers_edge_cases() {
+		// Test with only one included TLV at the start
+		let mut tlv_bytes = Vec::new();
+		tlv_bytes.extend_from_slice(&[0x00, 0x04, 0x00, 0x00, 0x00, 0x00]); // TLV 0
+		tlv_bytes.extend_from_slice(&[0x0a, 0x02, 0x00, 0x00]); // TLV 10
+		tlv_bytes.extend_from_slice(&[0x14, 0x02, 0x00, 0x00]); // TLV 20
+		tlv_bytes.extend_from_slice(&[0x1e, 0x02, 0x00, 0x00]); // TLV 30
+
+		let mut included = BTreeSet::new();
+		included.insert(10);
+
+		let disclosure = compute_selective_disclosure(&tlv_bytes, &included).unwrap();
+
+		// After included type 10, omitted types 20 and 30 get markers 11 and 12
+		assert_eq!(disclosure.omitted_markers, vec![11, 12]);
+	}
+
+	/// Test that all included TLVs produce no omitted markers (except implicit TLV0).
+	#[test]
+	fn test_omitted_markers_all_included() {
+		let mut tlv_bytes = Vec::new();
+		tlv_bytes.extend_from_slice(&[0x00, 0x04, 0x00, 0x00, 0x00, 0x00]); // TLV 0 (always omitted)
+		tlv_bytes.extend_from_slice(&[0x0a, 0x02, 0x00, 0x00]); // TLV 10
+		tlv_bytes.extend_from_slice(&[0x14, 0x02, 0x00, 0x00]); // TLV 20
+
+		let mut included = BTreeSet::new();
+		included.insert(10);
+		included.insert(20);
+
+		let disclosure = compute_selective_disclosure(&tlv_bytes, &included).unwrap();
+
+		// Only TLV 0 is omitted (implicit), so no markers needed
+		assert!(disclosure.omitted_markers.is_empty());
+	}
+
+	/// Test validation of omitted_markers - must not contain 0.
+	#[test]
+	fn test_validate_omitted_markers_rejects_zero() {
+		let omitted = vec![0, 11, 12];
+		let included: BTreeSet<u64> = [10, 30].iter().copied().collect();
+
+		let result = validate_omitted_markers_for_parsing(&omitted, &included);
+		assert!(matches!(result, Err(PayerProofError::InvalidData(_))));
+	}
+
+	/// Test validation of omitted_markers - must not contain signature types.
+	#[test]
+	fn test_validate_omitted_markers_rejects_signature_types() {
+		// included=[10], markers=[1, 2, 250] — 250 is a signature type
+		let omitted = vec![1, 2, 250];
+		let included: BTreeSet<u64> = [10].iter().copied().collect();
+
+		let result = validate_omitted_markers_for_parsing(&omitted, &included);
+		assert!(matches!(result, Err(PayerProofError::InvalidData(_))));
+	}
+
+	/// Test validation of omitted_markers - must be strictly ascending.
+	#[test]
+	fn test_validate_omitted_markers_rejects_non_ascending() {
+		// markers=[1, 11, 9]: 1 ok, 11 ok (after included 10), but 9 <= 11 fails ascending
+		let omitted = vec![1, 11, 9];
+		let included: BTreeSet<u64> = [10, 30].iter().copied().collect();
+
+		let result = validate_omitted_markers_for_parsing(&omitted, &included);
+		assert!(matches!(result, Err(PayerProofError::InvalidData(_))));
+	}
+
+	/// Test validation of omitted_markers - must not contain included types.
+	#[test]
+	fn test_validate_omitted_markers_rejects_included_types() {
+		// included=[10, 30], markers=[1, 10] — 10 is in included set
+		let omitted = vec![1, 10];
+		let included: BTreeSet<u64> = [10, 30].iter().copied().collect();
+
+		let result = validate_omitted_markers_for_parsing(&omitted, &included);
+		assert!(matches!(result, Err(PayerProofError::OmittedMarkersContainIncluded)));
+	}
+
+	/// Test validation of omitted_markers - must not have too many trailing markers.
+	#[test]
+	fn test_validate_omitted_markers_rejects_too_many_trailing() {
+		// included=[10, 20], markers=[1, 21, 22] — both 21 and 22 > max included (20)
+		let omitted = vec![1, 21, 22];
+		let included: BTreeSet<u64> = [10, 20].iter().copied().collect();
+
+		let result = validate_omitted_markers_for_parsing(&omitted, &included);
+		assert!(matches!(result, Err(PayerProofError::TooManyTrailingOmittedMarkers)));
+	}
+
+	/// Test that valid minimized omitted_markers pass validation.
+	#[test]
+	fn test_validate_omitted_markers_accepts_valid() {
+		// Realistic payer proof: included types include required fields (88, 168, 176)
+		// so max_included=176 and markers are well below it.
+		// Layout: 0(omit), 10(incl), 20(omit), 30(omit), 40(incl), 50(omit), 88(incl),
+		//         168(incl), 176(incl)
+		// markers=[11, 12, 41, 89]
+		let omitted = vec![11, 12, 41, 89];
+		let included: BTreeSet<u64> = [10, 40, 88, 168, 176].iter().copied().collect();
+
+		let result = validate_omitted_markers_for_parsing(&omitted, &included);
+		assert!(result.is_ok());
+	}
+
+	/// Test that non-minimized markers are rejected.
+	#[test]
+	fn test_validate_omitted_markers_rejects_non_minimized() {
+		// included=[10, 40], markers=[11, 15, 41, 42]
+		// marker 15 should be 12 (continuation of run after 11)
+		let omitted = vec![11, 15, 41, 42];
+		let included: BTreeSet<u64> = [10, 40].iter().copied().collect();
+
+		let result = validate_omitted_markers_for_parsing(&omitted, &included);
+		assert!(matches!(result, Err(PayerProofError::InvalidData(_))));
+	}
+
+	/// Test that non-minimized first marker in a run is rejected.
+	#[test]
+	fn test_validate_omitted_markers_rejects_non_minimized_run_start() {
+		// included=[10, 40], markers=[11, 12, 45, 46]
+		// marker 45 should be 41 (first omitted after included 40)
+		let omitted = vec![11, 12, 45, 46];
+		let included: BTreeSet<u64> = [10, 40].iter().copied().collect();
+
+		let result = validate_omitted_markers_for_parsing(&omitted, &included);
+		assert!(matches!(result, Err(PayerProofError::InvalidData(_))));
+	}
+
+	/// Test minimized markers with omitted TLVs before any included type.
+	#[test]
+	fn test_validate_omitted_markers_accepts_leading_run() {
+		// included=[40], markers=[1, 2, 41]
+		// Two omitted before any included type, one after 40
+		let omitted = vec![1, 2, 41];
+		let included: BTreeSet<u64> = [40].iter().copied().collect();
+
+		let result = validate_omitted_markers_for_parsing(&omitted, &included);
+		assert!(result.is_ok());
+	}
+
+	/// Test minimized markers with consecutive included types (no markers between them).
+	#[test]
+	fn test_validate_omitted_markers_accepts_consecutive_included() {
+		// included=[10, 20, 40], markers=[1, 41]
+		// One omitted before 10, no omitted between 10-20 or 20-40, one after 40
+		let omitted = vec![1, 41];
+		let included: BTreeSet<u64> = [10, 20, 40].iter().copied().collect();
+
+		let result = validate_omitted_markers_for_parsing(&omitted, &included);
+		assert!(result.is_ok());
+	}
+
+	/// Test that invreq_metadata (type 0) cannot be explicitly included via include_type.
+	#[test]
+	fn test_invreq_metadata_not_allowed() {
+		assert_eq!(PAYER_METADATA_TYPE, 0);
+	}
+
+	/// Test that out-of-order TLVs are rejected during parsing.
+	#[test]
+	fn test_parsing_rejects_out_of_order_tlvs() {
+		use core::convert::TryFrom;
+
+		// Create a malformed TLV stream with out-of-order types (20 before 10)
+		// TLV format: type (BigSize) || length (BigSize) || value
+		let mut bytes = Vec::new();
+		// TLV type 20, length 2, value
+		bytes.extend_from_slice(&[0x14, 0x02, 0x00, 0x00]);
+		// TLV type 10, length 2, value (OUT OF ORDER!)
+		bytes.extend_from_slice(&[0x0a, 0x02, 0x00, 0x00]);
+
+		let result = PayerProof::try_from(bytes);
+		assert!(result.is_err());
+	}
+
+	/// Test that duplicate TLVs are rejected during parsing.
+	#[test]
+	fn test_parsing_rejects_duplicate_tlvs() {
+		use core::convert::TryFrom;
+
+		// Create a malformed TLV stream with duplicate type 10
+		let mut bytes = Vec::new();
+		// TLV type 10, length 2, value
+		bytes.extend_from_slice(&[0x0a, 0x02, 0x00, 0x00]);
+		// TLV type 10 again (DUPLICATE!)
+		bytes.extend_from_slice(&[0x0a, 0x02, 0x00, 0x00]);
+
+		let result = PayerProof::try_from(bytes);
+		assert!(result.is_err());
+	}
+
+	/// Test that invalid hash lengths (not multiple of 32) are rejected.
+	#[test]
+	fn test_parsing_rejects_invalid_hash_length() {
+		use core::convert::TryFrom;
+
+		// Create a TLV stream with missing_hashes (type 246) that has invalid length
+		// BigSize encoding: values 0-252 are single byte, 253-65535 use 0xFD prefix
+		let mut bytes = Vec::new();
+		// TLV type 246 (missing_hashes) - 246 < 253 so single byte
+		bytes.push(0xf6); // type 246
+		bytes.push(0x21); // length 33 (not multiple of 32!)
+		bytes.extend_from_slice(&[0x00; 33]); // 33 bytes of zeros
+
+		let result = PayerProof::try_from(bytes);
+		assert!(result.is_err());
+	}
+
+	/// Test that invalid leaf_hashes length (not multiple of 32) is rejected.
+	#[test]
+	fn test_parsing_rejects_invalid_leaf_hashes_length() {
+		use core::convert::TryFrom;
+
+		// Create a TLV stream with leaf_hashes (type 248) that has invalid length
+		// BigSize encoding: values 0-252 are single byte, 253-65535 use 0xFD prefix
+		let mut bytes = Vec::new();
+		// TLV type 248 (leaf_hashes) - 248 < 253 so single byte
+		bytes.push(0xf8); // type 248
+		bytes.push(0x1f); // length 31 (not multiple of 32!)
+		bytes.extend_from_slice(&[0x00; 31]); // 31 bytes of zeros
+
+		let result = PayerProof::try_from(bytes);
+		assert!(result.is_err());
+	}
+}

--- a/lightning/src/offers/payer_proof.rs
+++ b/lightning/src/offers/payer_proof.rs
@@ -766,8 +766,10 @@ impl core::fmt::Display for PayerProof {
 mod tests {
 	use super::*;
 	use crate::offers::merkle::compute_selective_disclosure;
+	use crate::util::ser::HighZeroBytesDroppedBigSize;
 	use bitcoin::hashes::Hash;
 	use bitcoin::secp256k1::{Keypair, Secp256k1, SecretKey};
+	use core::time::Duration;
 
 	const EXPERIMENTAL_TEST_TLV_TYPE: u64 = 1_000_000_001;
 
@@ -873,6 +875,71 @@ mod tests {
 				.collect();
 		let disclosure = compute_selective_disclosure(&invoice_bytes, &included_types).unwrap();
 		assert_eq!(disclosure.omitted_markers, vec![177, 178]);
+
+		let unsigned = UnsignedPayerProof {
+			invoice_signature,
+			preimage,
+			payer_id,
+			payment_hash,
+			issuer_signing_pubkey,
+			invoice_bytes,
+			included_types,
+			disclosure,
+		};
+
+		unsigned
+			.sign(|message| Ok(secp_ctx.sign_schnorr_no_aux_rand(message, &payer_keys)), None)
+			.unwrap()
+	}
+
+	fn build_round_trip_proof_with_disclosed_fields() -> PayerProof {
+		let secp_ctx = Secp256k1::new();
+
+		let payer_secret = SecretKey::from_slice(&[62; 32]).unwrap();
+		let payer_keys = Keypair::from_secret_key(&secp_ctx, &payer_secret);
+		let payer_id = payer_keys.public_key();
+
+		let issuer_secret = SecretKey::from_slice(&[63; 32]).unwrap();
+		let issuer_keys = Keypair::from_secret_key(&secp_ctx, &issuer_secret);
+		let issuer_signing_pubkey = issuer_keys.public_key();
+
+		let preimage = PaymentPreimage([64; 32]);
+		let payment_hash = PaymentHash(sha256::Hash::hash(&preimage.0).to_byte_array());
+
+		let mut invoice_bytes = Vec::new();
+		write_tlv_record_bytes(&mut invoice_bytes, PAYER_METADATA_TYPE, &[65; 32]);
+		write_tlv_record_bytes(&mut invoice_bytes, OFFER_DESCRIPTION_TYPE, b"coffee beans");
+		write_tlv_record_bytes(&mut invoice_bytes, OFFER_ISSUER_TYPE, b"LDK Roastery");
+		write_tlv_record(&mut invoice_bytes, INVOICE_REQUEST_PAYER_ID_TYPE, &payer_id);
+		write_tlv_record(
+			&mut invoice_bytes,
+			INVOICE_CREATED_AT_TYPE,
+			&HighZeroBytesDroppedBigSize(1_700_000_000u64),
+		);
+		write_tlv_record(&mut invoice_bytes, INVOICE_PAYMENT_HASH_TYPE, &payment_hash);
+		write_tlv_record(
+			&mut invoice_bytes,
+			INVOICE_AMOUNT_TYPE,
+			&HighZeroBytesDroppedBigSize(42_000u64),
+		);
+		write_tlv_record(&mut invoice_bytes, INVOICE_NODE_ID_TYPE, &issuer_signing_pubkey);
+
+		let invoice_message = TaggedHash::from_valid_tlv_stream_bytes(SIGNATURE_TAG, &invoice_bytes);
+		let invoice_signature =
+			secp_ctx.sign_schnorr_no_aux_rand(invoice_message.as_digest(), &issuer_keys);
+
+		let included_types: BTreeSet<u64> = [
+			OFFER_DESCRIPTION_TYPE,
+			OFFER_ISSUER_TYPE,
+			INVOICE_REQUEST_PAYER_ID_TYPE,
+			INVOICE_CREATED_AT_TYPE,
+			INVOICE_PAYMENT_HASH_TYPE,
+			INVOICE_AMOUNT_TYPE,
+			INVOICE_NODE_ID_TYPE,
+		]
+		.into_iter()
+		.collect();
+		let disclosure = compute_selective_disclosure(&invoice_bytes, &included_types).unwrap();
 
 		let unsigned = UnsignedPayerProof {
 			invoice_signature,
@@ -1235,6 +1302,17 @@ mod tests {
 			"Multiple trailing omitted TLVs should survive payer proof parsing: {:?}",
 			result
 		);
+	}
+
+	#[test]
+	fn test_parsed_proof_exposes_disclosed_fields() {
+		let proof = build_round_trip_proof_with_disclosed_fields();
+		let parsed = PayerProof::try_from(proof.bytes().to_vec()).unwrap();
+
+		assert_eq!(parsed.offer_description().map(|s| s.0), Some("coffee beans"));
+		assert_eq!(parsed.offer_issuer().map(|s| s.0), Some("LDK Roastery"));
+		assert_eq!(parsed.invoice_amount_msats(), Some(42_000));
+		assert_eq!(parsed.invoice_created_at(), Some(Duration::from_secs(1_700_000_000)));
 	}
 
 	/// Test that unknown even TLV types >= 240 are rejected during parsing.

--- a/lightning/src/offers/payer_proof.rs
+++ b/lightning/src/offers/payer_proof.rs
@@ -771,6 +771,80 @@ impl core::fmt::Display for PayerProof {
 mod tests {
 	use super::*;
 	use crate::offers::merkle::compute_selective_disclosure;
+	use bitcoin::hashes::Hash;
+	use bitcoin::secp256k1::{Keypair, Secp256k1, SecretKey};
+
+	const EXPERIMENTAL_TEST_TLV_TYPE: u64 = 1_000_000_001;
+
+	fn write_tlv_record<T: Writeable>(bytes: &mut Vec<u8>, tlv_type: u64, value: &T) {
+		let mut value_bytes = Vec::new();
+		value.write(&mut value_bytes).expect("Vec write should not fail");
+
+		BigSize(tlv_type).write(bytes).expect("Vec write should not fail");
+		BigSize(value_bytes.len() as u64).write(bytes).expect("Vec write should not fail");
+		bytes.extend_from_slice(&value_bytes);
+	}
+
+	fn write_tlv_record_bytes(bytes: &mut Vec<u8>, tlv_type: u64, value_bytes: &[u8]) {
+		BigSize(tlv_type).write(bytes).expect("Vec write should not fail");
+		BigSize(value_bytes.len() as u64).write(bytes).expect("Vec write should not fail");
+		bytes.extend_from_slice(value_bytes);
+	}
+
+	fn build_round_trip_proof_with_included_experimental_tlv() -> PayerProof {
+		let secp_ctx = Secp256k1::new();
+
+		let payer_secret = SecretKey::from_slice(&[42; 32]).unwrap();
+		let payer_keys = Keypair::from_secret_key(&secp_ctx, &payer_secret);
+		let payer_id = payer_keys.public_key();
+
+		let issuer_secret = SecretKey::from_slice(&[43; 32]).unwrap();
+		let issuer_keys = Keypair::from_secret_key(&secp_ctx, &issuer_secret);
+		let issuer_signing_pubkey = issuer_keys.public_key();
+
+		let preimage = PaymentPreimage([44; 32]);
+		let payment_hash = PaymentHash(sha256::Hash::hash(&preimage.0).to_byte_array());
+
+		let mut invoice_bytes = Vec::new();
+		write_tlv_record_bytes(&mut invoice_bytes, PAYER_METADATA_TYPE, &[45; 32]);
+		write_tlv_record(&mut invoice_bytes, INVOICE_REQUEST_PAYER_ID_TYPE, &payer_id);
+		write_tlv_record(&mut invoice_bytes, INVOICE_PAYMENT_HASH_TYPE, &payment_hash);
+		write_tlv_record(&mut invoice_bytes, INVOICE_NODE_ID_TYPE, &issuer_signing_pubkey);
+		write_tlv_record_bytes(
+			&mut invoice_bytes,
+			EXPERIMENTAL_TEST_TLV_TYPE,
+			b"experimental-payer-proof-field",
+		);
+
+		let invoice_message = TaggedHash::from_valid_tlv_stream_bytes(SIGNATURE_TAG, &invoice_bytes);
+		let invoice_signature =
+			secp_ctx.sign_schnorr_no_aux_rand(invoice_message.as_digest(), &issuer_keys);
+
+		let included_types: BTreeSet<u64> = [
+			INVOICE_REQUEST_PAYER_ID_TYPE,
+			INVOICE_PAYMENT_HASH_TYPE,
+			INVOICE_NODE_ID_TYPE,
+			EXPERIMENTAL_TEST_TLV_TYPE,
+		]
+		.into_iter()
+		.collect();
+		let disclosure = compute_selective_disclosure(&invoice_bytes, &included_types).unwrap();
+
+		let unsigned = UnsignedPayerProof {
+			invoice_signature,
+			preimage,
+			payer_id,
+			payment_hash,
+			issuer_signing_pubkey,
+			invoice_bytes,
+			included_types,
+			disclosure,
+		};
+
+		unsigned
+			.sign(|message| Ok(secp_ctx.sign_schnorr_no_aux_rand(message, &payer_keys)), None)
+			.unwrap()
+	}
 
 	#[test]
 	fn test_selective_disclosure_computation() {
@@ -1078,26 +1152,34 @@ mod tests {
 			if tlv_type == PAYER_METADATA_TYPE {
 				return Err(PayerProofError::InvreqMetadataNotAllowed);
 			}
-			if tlv_type >= TLV_SIGNATURE {
+			if SIGNATURE_TYPES.contains(&tlv_type) {
 				return Err(PayerProofError::SignatureTypeNotAllowed);
 			}
 			Ok(())
 		}
 
-		// All types >= 240 must be rejected
+		// Signature-range types 240..=1000 must be rejected.
 		assert!(matches!(check_include_type(240), Err(PayerProofError::SignatureTypeNotAllowed)));
 		assert!(matches!(check_include_type(250), Err(PayerProofError::SignatureTypeNotAllowed)));
 		assert!(matches!(check_include_type(1000), Err(PayerProofError::SignatureTypeNotAllowed)));
-		// Types > 1000 (experimental) must also be rejected
-		assert!(matches!(check_include_type(1001), Err(PayerProofError::SignatureTypeNotAllowed)));
-		assert!(matches!(
-			check_include_type(u64::MAX),
-			Err(PayerProofError::SignatureTypeNotAllowed)
-		));
+		// Types above 1000 are experimental/non-signature TLVs and should remain includable.
+		assert!(check_include_type(1001).is_ok());
+		assert!(check_include_type(u64::MAX).is_ok());
 		// Just below the boundary
 		assert!(check_include_type(239).is_ok());
 		// Payer metadata still rejected
 		assert!(matches!(check_include_type(0), Err(PayerProofError::InvreqMetadataNotAllowed)));
+	}
+
+	#[test]
+	fn test_round_trip_accepts_included_experimental_tlv() {
+		let proof = build_round_trip_proof_with_included_experimental_tlv();
+		let result = PayerProof::try_from(proof.bytes().to_vec());
+		assert!(
+			result.is_ok(),
+			"Included experimental TLVs should survive payer proof parsing: {:?}",
+			result
+		);
 	}
 
 	/// Test that unknown even TLV types >= 240 are rejected during parsing.

--- a/lightning/src/offers/payer_proof.rs
+++ b/lightning/src/offers/payer_proof.rs
@@ -854,6 +854,55 @@ mod tests {
 			.unwrap()
 	}
 
+	fn build_round_trip_proof_with_multiple_trailing_omitted_tlvs() -> PayerProof {
+		let secp_ctx = Secp256k1::new();
+
+		let payer_secret = SecretKey::from_slice(&[52; 32]).unwrap();
+		let payer_keys = Keypair::from_secret_key(&secp_ctx, &payer_secret);
+		let payer_id = payer_keys.public_key();
+
+		let issuer_secret = SecretKey::from_slice(&[53; 32]).unwrap();
+		let issuer_keys = Keypair::from_secret_key(&secp_ctx, &issuer_secret);
+		let issuer_signing_pubkey = issuer_keys.public_key();
+
+		let preimage = PaymentPreimage([54; 32]);
+		let payment_hash = PaymentHash(sha256::Hash::hash(&preimage.0).to_byte_array());
+
+		let mut invoice_bytes = Vec::new();
+		write_tlv_record_bytes(&mut invoice_bytes, PAYER_METADATA_TYPE, &[55; 32]);
+		write_tlv_record(&mut invoice_bytes, INVOICE_REQUEST_PAYER_ID_TYPE, &payer_id);
+		write_tlv_record(&mut invoice_bytes, INVOICE_PAYMENT_HASH_TYPE, &payment_hash);
+		write_tlv_record(&mut invoice_bytes, INVOICE_NODE_ID_TYPE, &issuer_signing_pubkey);
+		write_tlv_record_bytes(&mut invoice_bytes, 1_000_000_001, b"first-omitted-experimental");
+		write_tlv_record_bytes(&mut invoice_bytes, 1_000_000_003, b"second-omitted-experimental");
+
+		let invoice_message = TaggedHash::from_valid_tlv_stream_bytes(SIGNATURE_TAG, &invoice_bytes);
+		let invoice_signature =
+			secp_ctx.sign_schnorr_no_aux_rand(invoice_message.as_digest(), &issuer_keys);
+
+		let included_types: BTreeSet<u64> =
+			[INVOICE_REQUEST_PAYER_ID_TYPE, INVOICE_PAYMENT_HASH_TYPE, INVOICE_NODE_ID_TYPE]
+				.into_iter()
+				.collect();
+		let disclosure = compute_selective_disclosure(&invoice_bytes, &included_types).unwrap();
+		assert_eq!(disclosure.omitted_markers, vec![177, 178]);
+
+		let unsigned = UnsignedPayerProof {
+			invoice_signature,
+			preimage,
+			payer_id,
+			payment_hash,
+			issuer_signing_pubkey,
+			invoice_bytes,
+			included_types,
+			disclosure,
+		};
+
+		unsigned
+			.sign(|message| Ok(secp_ctx.sign_schnorr_no_aux_rand(message, &payer_keys)), None)
+			.unwrap()
+	}
+
 	#[test]
 	fn test_selective_disclosure_computation() {
 		// Test that the merkle selective disclosure works correctly
@@ -1186,6 +1235,17 @@ mod tests {
 		assert!(
 			result.is_ok(),
 			"Included experimental TLVs should survive payer proof parsing: {:?}",
+			result
+		);
+	}
+
+	#[test]
+	fn test_round_trip_accepts_multiple_trailing_omitted_tlvs() {
+		let proof = build_round_trip_proof_with_multiple_trailing_omitted_tlvs();
+		let result = PayerProof::try_from(proof.bytes().to_vec());
+		assert!(
+			result.is_ok(),
+			"Multiple trailing omitted TLVs should survive payer proof parsing: {:?}",
 			result
 		);
 	}

--- a/lightning/src/offers/payer_proof.rs
+++ b/lightning/src/offers/payer_proof.rs
@@ -698,7 +698,6 @@ impl TryFrom<Vec<u8>> for PayerProof {
 /// - MUST NOT contain signature TLV element numbers (240-1000)
 /// - MUST be in strict ascending order
 /// - MUST NOT contain the number of an included TLV field
-/// - MUST NOT contain more than one number larger than the largest included non-signature TLV
 /// - Markers MUST be minimized: each marker must be exactly prev_value + 1 within
 ///   a run, and the first marker after an included type X must be X + 1
 fn validate_omitted_markers_for_parsing(
@@ -707,8 +706,6 @@ fn validate_omitted_markers_for_parsing(
 	let mut inc_iter = included_types.iter().copied().peekable();
 	// After implicit TLV0 (marker 0), the first minimized marker would be 1
 	let mut expected_next: u64 = 1;
-	let mut trailing_count = 0;
-	let max_included = included_types.iter().copied().max().unwrap_or(0);
 	let mut prev = 0u64;
 
 	for &marker in omitted_markers {
@@ -753,17 +750,7 @@ fn validate_omitted_markers_for_parsing(
 
 		expected_next = marker + 1;
 
-		// Count markers larger than largest included
-		if marker > max_included {
-			trailing_count += 1;
-		}
-
 		prev = marker;
-	}
-
-	// MUST NOT contain more than one number larger than largest included
-	if trailing_count > 1 {
-		return Err(crate::ln::msgs::DecodeError::InvalidValue);
 	}
 
 	Ok(())
@@ -1050,15 +1037,15 @@ mod tests {
 		assert!(matches!(result, Err(crate::ln::msgs::DecodeError::InvalidValue)));
 	}
 
-	/// Test validation of omitted_markers - must not have too many trailing markers.
+	/// Test validation of omitted_markers with multiple trailing markers.
 	#[test]
-	fn test_validate_omitted_markers_rejects_too_many_trailing() {
+	fn test_validate_omitted_markers_accepts_multiple_trailing_markers() {
 		// included=[10, 20], markers=[1, 21, 22] — both 21 and 22 > max included (20)
 		let omitted = vec![1, 21, 22];
 		let included: BTreeSet<u64> = [10, 20].iter().copied().collect();
 
 		let result = validate_omitted_markers_for_parsing(&omitted, &included);
-		assert!(matches!(result, Err(crate::ln::msgs::DecodeError::InvalidValue)));
+		assert!(result.is_ok());
 	}
 
 	/// Test that valid minimized omitted_markers pass validation.

--- a/lightning/src/offers/payer_proof.rs
+++ b/lightning/src/offers/payer_proof.rs
@@ -35,7 +35,7 @@ use crate::offers::offer::{OFFER_DESCRIPTION_TYPE, OFFER_ISSUER_TYPE};
 use crate::offers::parse::Bech32Encode;
 use crate::offers::payer::PAYER_METADATA_TYPE;
 use crate::types::payment::{PaymentHash, PaymentPreimage};
-use crate::util::ser::{BigSize, Readable, Writeable};
+use crate::util::ser::{BigSize, HighZeroBytesDroppedBigSize, Readable, Writeable};
 use lightning_types::string::PrintableString;
 
 use bitcoin::hashes::{sha256, Hash, HashEngine};
@@ -43,6 +43,7 @@ use bitcoin::secp256k1::schnorr::Signature;
 use bitcoin::secp256k1::{Message, PublicKey, Secp256k1};
 
 use core::convert::TryFrom;
+use core::time::Duration;
 
 #[allow(unused_imports)]
 use crate::prelude::*;
@@ -118,6 +119,15 @@ struct PayerProofContents {
 	invoice_signature: Signature,
 	payer_signature: Signature,
 	payer_note: Option<String>,
+	disclosed_fields: DisclosedFields,
+}
+
+#[derive(Clone, Debug, Default)]
+struct DisclosedFields {
+	offer_description: Option<String>,
+	offer_issuer: Option<String>,
+	invoice_amount_msats: Option<u64>,
+	invoice_created_at: Option<Duration>,
 }
 
 /// Builds a [`PayerProof`] from a paid invoice and its preimage.
@@ -243,6 +253,10 @@ impl<'a> PayerProofBuilder<'a> {
 		for r in TlvStream::new(&invoice_bytes).filter(|r| !SIGNATURE_TYPES.contains(&r.r#type)) {
 			bytes_without_sig.extend_from_slice(r.record_bytes);
 		}
+		let disclosed_fields = extract_disclosed_fields(
+			TlvStream::new(&invoice_bytes)
+				.filter(|r| self.included_types.contains(&r.r#type) && !SIGNATURE_TYPES.contains(&r.r#type)),
+		)?;
 
 		let disclosure =
 			merkle::compute_selective_disclosure(&bytes_without_sig, &self.included_types)?;
@@ -257,6 +271,7 @@ impl<'a> PayerProofBuilder<'a> {
 			issuer_signing_pubkey: self.invoice.signing_pubkey(),
 			invoice_bytes,
 			included_types: self.included_types,
+			disclosed_fields,
 			disclosure,
 		})
 	}
@@ -271,6 +286,7 @@ struct UnsignedPayerProof {
 	issuer_signing_pubkey: PublicKey,
 	invoice_bytes: Vec<u8>,
 	included_types: BTreeSet<u64>,
+	disclosed_fields: DisclosedFields,
 	disclosure: SelectiveDisclosure,
 }
 
@@ -299,6 +315,7 @@ impl UnsignedPayerProof {
 				invoice_signature: self.invoice_signature,
 				payer_signature,
 				payer_note: note.map(String::from),
+				disclosed_fields: self.disclosed_fields,
 			},
 			merkle_root: self.disclosure.merkle_root,
 		})
@@ -426,8 +443,28 @@ impl PayerProof {
 		self.contents.payer_signature
 	}
 
+	/// The disclosed offer description, if included in the proof.
+	pub fn offer_description(&self) -> Option<PrintableString<'_>> {
+		self.contents.disclosed_fields.offer_description.as_deref().map(PrintableString)
+	}
+
+	/// The disclosed offer issuer, if included in the proof.
+	pub fn offer_issuer(&self) -> Option<PrintableString<'_>> {
+		self.contents.disclosed_fields.offer_issuer.as_deref().map(PrintableString)
+	}
+
+	/// The disclosed invoice amount, if included in the proof.
+	pub fn invoice_amount_msats(&self) -> Option<u64> {
+		self.contents.disclosed_fields.invoice_amount_msats
+	}
+
+	/// The disclosed invoice creation time, if included in the proof.
+	pub fn invoice_created_at(&self) -> Option<Duration> {
+		self.contents.disclosed_fields.invoice_created_at
+	}
+
 	/// The payer's note, if any.
-	pub fn payer_note(&self) -> Option<PrintableString> {
+	pub fn payer_note(&self) -> Option<PrintableString<'_>> {
 		self.contents.payer_note.as_deref().map(PrintableString)
 	}
 
@@ -473,6 +510,47 @@ fn validate_tlv_framing(bytes: &[u8]) -> Result<(), crate::ln::msgs::DecodeError
 	Ok(())
 }
 
+fn update_disclosed_fields(
+	record: &crate::offers::merkle::TlvRecord<'_>, disclosed_fields: &mut DisclosedFields,
+) -> Result<(), crate::ln::msgs::DecodeError> {
+	use crate::ln::msgs::DecodeError;
+
+	match record.r#type {
+		OFFER_DESCRIPTION_TYPE => {
+			disclosed_fields.offer_description = Some(
+				String::from_utf8(record.value_bytes.to_vec()).map_err(|_| DecodeError::InvalidValue)?,
+			);
+		},
+		OFFER_ISSUER_TYPE => {
+			disclosed_fields.offer_issuer = Some(
+				String::from_utf8(record.value_bytes.to_vec()).map_err(|_| DecodeError::InvalidValue)?,
+			);
+		},
+		INVOICE_CREATED_AT_TYPE => {
+			disclosed_fields.invoice_created_at = Some(Duration::from_secs(
+				record.read_value::<HighZeroBytesDroppedBigSize<u64>>()?.0,
+			));
+		},
+		INVOICE_AMOUNT_TYPE => {
+			disclosed_fields.invoice_amount_msats =
+				Some(record.read_value::<HighZeroBytesDroppedBigSize<u64>>()?.0);
+		},
+		_ => {},
+	}
+
+	Ok(())
+}
+
+fn extract_disclosed_fields<'a>(
+	records: impl core::iter::Iterator<Item = crate::offers::merkle::TlvRecord<'a>>,
+) -> Result<DisclosedFields, crate::ln::msgs::DecodeError> {
+	let mut disclosed_fields = DisclosedFields::default();
+	for record in records {
+		update_disclosed_fields(&record, &mut disclosed_fields)?;
+	}
+	Ok(disclosed_fields)
+}
+
 // Payer proofs use manual TLV parsing rather than `ParsedMessage` / `tlv_stream!`
 // because of their hybrid structure: a dynamic, variable set of included invoice
 // TLV records (types 0-239, preserved as raw bytes for merkle reconstruction) plus
@@ -502,6 +580,7 @@ impl TryFrom<Vec<u8>> for PayerProof {
 		let mut preimage: Option<PaymentPreimage> = None;
 		let mut payer_signature: Option<Signature> = None;
 		let mut payer_note: Option<String> = None;
+		let mut disclosed_fields = DisclosedFields::default();
 
 		let mut leaf_hashes: Vec<sha256::Hash> = Vec::new();
 		let mut omitted_markers: Vec<u64> = Vec::new();
@@ -522,6 +601,7 @@ impl TryFrom<Vec<u8>> for PayerProof {
 				}
 			}
 			prev_tlv_type = Some(tlv_type);
+			update_disclosed_fields(&record, &mut disclosed_fields)?;
 
 			match tlv_type {
 				INVOICE_REQUEST_PAYER_ID_TYPE => {
@@ -677,17 +757,18 @@ impl TryFrom<Vec<u8>> for PayerProof {
 
 		Ok(PayerProof {
 			bytes,
-			contents: PayerProofContents {
-				payer_id,
-				payment_hash,
-				issuer_signing_pubkey,
-				preimage,
-				invoice_signature,
-				payer_signature,
-				payer_note,
-			},
-			merkle_root,
-		})
+				contents: PayerProofContents {
+					payer_id,
+					payment_hash,
+					issuer_signing_pubkey,
+					preimage,
+					invoice_signature,
+					payer_signature,
+					payer_note,
+					disclosed_fields,
+				},
+				merkle_root,
+			})
 	}
 }
 
@@ -825,6 +906,10 @@ mod tests {
 		]
 		.into_iter()
 		.collect();
+		let disclosed_fields = extract_disclosed_fields(
+			TlvStream::new(&invoice_bytes).filter(|r| included_types.contains(&r.r#type)),
+		)
+		.unwrap();
 		let disclosure = compute_selective_disclosure(&invoice_bytes, &included_types).unwrap();
 
 		let unsigned = UnsignedPayerProof {
@@ -835,6 +920,7 @@ mod tests {
 			issuer_signing_pubkey,
 			invoice_bytes,
 			included_types,
+			disclosed_fields,
 			disclosure,
 		};
 
@@ -873,6 +959,10 @@ mod tests {
 			[INVOICE_REQUEST_PAYER_ID_TYPE, INVOICE_PAYMENT_HASH_TYPE, INVOICE_NODE_ID_TYPE]
 				.into_iter()
 				.collect();
+		let disclosed_fields = extract_disclosed_fields(
+			TlvStream::new(&invoice_bytes).filter(|r| included_types.contains(&r.r#type)),
+		)
+		.unwrap();
 		let disclosure = compute_selective_disclosure(&invoice_bytes, &included_types).unwrap();
 		assert_eq!(disclosure.omitted_markers, vec![177, 178]);
 
@@ -884,6 +974,7 @@ mod tests {
 			issuer_signing_pubkey,
 			invoice_bytes,
 			included_types,
+			disclosed_fields,
 			disclosure,
 		};
 
@@ -939,6 +1030,10 @@ mod tests {
 		]
 		.into_iter()
 		.collect();
+		let disclosed_fields = extract_disclosed_fields(
+			TlvStream::new(&invoice_bytes).filter(|r| included_types.contains(&r.r#type)),
+		)
+		.unwrap();
 		let disclosure = compute_selective_disclosure(&invoice_bytes, &included_types).unwrap();
 
 		let unsigned = UnsignedPayerProof {
@@ -949,6 +1044,7 @@ mod tests {
 			issuer_signing_pubkey,
 			invoice_bytes,
 			included_types,
+			disclosed_fields,
 			disclosure,
 		};
 


### PR DESCRIPTION
## Summary
- allow selectively disclosed experimental invoice TLVs above the reserved `240..=1000` payer-proof/signature range
- accept multiple trailing `omitted_tlvs` markers during payer-proof parsing
- expose disclosed optional fields after parsing instead of discarding them
- add focused payer-proof regression tests for each fix

## Spec context
The experimental TLV fix follows [BOLT PR #1295](https://github.com/lightning/bolts/pull/1295/files), which reserves only `240..=1000` for payer-proof/signature TLVs. Experimental invoice TLVs above that range must remain selectively disclosable.

The matching test-vector PR is [vincenzopalazzo/payer-proof-test-vectors#4](https://github.com/vincenzopalazzo/payer-proof-test-vectors/pull/4).

## Test plan
- `cargo check -p lightning --lib`
- attempted: `cargo test -p lightning test_round_trip_accepts_included_experimental_tlv -- --nocapture`
- attempted: `cargo test -p lightning test_round_trip_accepts_multiple_trailing_omitted_tlvs -- --nocapture`
- attempted: `cargo test -p lightning test_parsed_proof_exposes_disclosed_fields -- --nocapture`

## Known blocker
The targeted `cargo test` invocations are currently blocked by a pre-existing compile error in `lightning/src/ln/splicing_tests.rs:2434`:
`RecipientOnionFields::secret_only(payment_secret)` now requires a second `u64` argument.
