### PR TITLE
Include payment_nonce in PaymentSent for payer proof construction

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -320,3 +320,19 @@ jobs:
         run: cargo fmt --check
       - name: Run rustfmt checks on lightning-tests
         run: cd lightning-tests && cargo fmt --check
+  tor-connect:
+    runs-on: ubuntu-latest
+    env:
+      TOOLCHAIN: 1.75.0
+    steps:
+      - name: Checkout source code
+        uses: actions/checkout@v4
+      - name: Install tor
+        run: |
+          sudo apt install -y tor
+      - name: Install Rust ${{ env.TOOLCHAIN }} toolchain
+        run: |
+          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile=minimal --default-toolchain ${{ env.TOOLCHAIN }}
+      - name: Test tor connections using lightning-net-tokio
+        run: |
+          TOR_PROXY="127.0.0.1:9050" RUSTFLAGS="--cfg=tor" cargo test --verbose --color always -p lightning-net-tokio

--- a/.github/workflows/semver.yml
+++ b/.github/workflows/semver.yml
@@ -13,10 +13,6 @@ jobs:
     steps:
       - name: Checkout source code
         uses: actions/checkout@v4
-      - name: Install Rust stable toolchain
-        run: |
-          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile=minimal --default-toolchain stable
-          rustup override set stable
       - name: Check SemVer with default features
         uses: obi1kenobi/cargo-semver-checks-action@v2
         with:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -190,6 +190,8 @@ welcomed.
   * `FULL_BLOCK_VIA_LISTEN`
   * `FULL_BLOCK_DISCONNECTIONS_SKIPPING_VIA_LISTEN`
 
+* `LDK_TEST_DETERMINISTIC_HASHES` - When set to `1`, uses deterministic hash map iteration order in tests. This ensures consistent test output across runs, useful for comparing logs before and after changes.
+
 C/C++ Bindings
 --------------
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -192,6 +192,12 @@ welcomed.
 
 * `LDK_TEST_DETERMINISTIC_HASHES` - When set to `1`, uses deterministic hash map iteration order in tests. This ensures consistent test output across runs, useful for comparing logs before and after changes.
 
+* `LDK_TEST_REBUILD_MGR_FROM_MONITORS` - If set to `1`, on test node reload the `ChannelManager`'s
+  HTLC set will be reconstructed from `Channel{Monitor}` persisted data. If `0`, test nodes will be
+  reloaded from persisted `ChannelManager` data using legacy code paths. This ensures consistent
+  test output across runs, useful for comparing logs before and after changes, since otherwise the
+  selection of which codepaths to be used on reload will be chosen randomly.
+
 C/C++ Bindings
 --------------
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -176,6 +176,20 @@ Fuzzing is heavily encouraged: you will find all related material under `fuzz/`
 Mutation testing is work-in-progress; any contribution there would be warmly
 welcomed.
 
+### Environment Variables
+
+* `LDK_TEST_CONNECT_STYLE` - Override the random block connect style used in tests for deterministic runs. Valid values:
+  * `BEST_BLOCK_FIRST`
+  * `BEST_BLOCK_FIRST_SKIPPING_BLOCKS`
+  * `BEST_BLOCK_FIRST_REORGS_ONLY_TIP`
+  * `TRANSACTIONS_FIRST`
+  * `TRANSACTIONS_FIRST_SKIPPING_BLOCKS`
+  * `TRANSACTIONS_DUPLICATIVELY_FIRST_SKIPPING_BLOCKS`
+  * `HIGHLY_REDUNDANT_TRANSACTIONS_FIRST_SKIPPING_BLOCKS`
+  * `TRANSACTIONS_FIRST_REORGS_ONLY_TIP`
+  * `FULL_BLOCK_VIA_LISTEN`
+  * `FULL_BLOCK_DISCONNECTIONS_SKIPPING_VIA_LISTEN`
+
 C/C++ Bindings
 --------------
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,4 +67,5 @@ check-cfg = [
     "cfg(require_route_graph_test)",
     "cfg(simple_close)",
     "cfg(peer_storage)",
+    "cfg(tor)",
 ]

--- a/fuzz/README.md
+++ b/fuzz/README.md
@@ -68,6 +68,19 @@ cargo +nightly fuzz run --features "libfuzzer_fuzz" msg_ping_target
 Note: If you encounter a `SIGKILL` during run/build check for OOM in kernel logs and consider
 increasing RAM size for VM.
 
+##### Fast builds for development
+
+The default build uses LTO and single codegen unit, which is slow. For faster iteration during
+development, use the `-D` (dev) flag:
+
+```shell
+cargo +nightly fuzz run --features "libfuzzer_fuzz" -D msg_ping_target
+```
+
+The `-D` flag builds in development mode with faster compilation (still has optimizations via
+`opt-level = 1`). The first build will be slow as it rebuilds the standard library with
+sanitizer instrumentation, but subsequent builds will be fast.
+
 If you wish to just generate fuzzing binary executables for `libFuzzer` and not run them:
 ```shell
 cargo +nightly fuzz build --features "libfuzzer_fuzz" msg_ping_target

--- a/fuzz/src/chanmon_consistency.rs
+++ b/fuzz/src/chanmon_consistency.rs
@@ -1860,11 +1860,8 @@ pub fn do_test<Out: Output>(data: &[u8], underlying_out: Out, anchors: bool) {
 
 			0xa0 => {
 				let input = FundingTxInput::new_p2wpkh(coinbase_tx.clone(), 0).unwrap();
-				let contribution = SpliceContribution::SpliceIn {
-					value: Amount::from_sat(10_000),
-					inputs: vec![input],
-					change_script: None,
-				};
+				let contribution =
+					SpliceContribution::splice_in(Amount::from_sat(10_000), vec![input], None);
 				let funding_feerate_sat_per_kw = fee_est_a.ret_val.load(atomic::Ordering::Acquire);
 				if let Err(e) = nodes[0].splice_channel(
 					&chan_a_id,
@@ -1882,11 +1879,8 @@ pub fn do_test<Out: Output>(data: &[u8], underlying_out: Out, anchors: bool) {
 			},
 			0xa1 => {
 				let input = FundingTxInput::new_p2wpkh(coinbase_tx.clone(), 1).unwrap();
-				let contribution = SpliceContribution::SpliceIn {
-					value: Amount::from_sat(10_000),
-					inputs: vec![input],
-					change_script: None,
-				};
+				let contribution =
+					SpliceContribution::splice_in(Amount::from_sat(10_000), vec![input], None);
 				let funding_feerate_sat_per_kw = fee_est_b.ret_val.load(atomic::Ordering::Acquire);
 				if let Err(e) = nodes[1].splice_channel(
 					&chan_a_id,
@@ -1904,11 +1898,8 @@ pub fn do_test<Out: Output>(data: &[u8], underlying_out: Out, anchors: bool) {
 			},
 			0xa2 => {
 				let input = FundingTxInput::new_p2wpkh(coinbase_tx.clone(), 0).unwrap();
-				let contribution = SpliceContribution::SpliceIn {
-					value: Amount::from_sat(10_000),
-					inputs: vec![input],
-					change_script: None,
-				};
+				let contribution =
+					SpliceContribution::splice_in(Amount::from_sat(10_000), vec![input], None);
 				let funding_feerate_sat_per_kw = fee_est_b.ret_val.load(atomic::Ordering::Acquire);
 				if let Err(e) = nodes[1].splice_channel(
 					&chan_b_id,
@@ -1926,11 +1917,8 @@ pub fn do_test<Out: Output>(data: &[u8], underlying_out: Out, anchors: bool) {
 			},
 			0xa3 => {
 				let input = FundingTxInput::new_p2wpkh(coinbase_tx.clone(), 1).unwrap();
-				let contribution = SpliceContribution::SpliceIn {
-					value: Amount::from_sat(10_000),
-					inputs: vec![input],
-					change_script: None,
-				};
+				let contribution =
+					SpliceContribution::splice_in(Amount::from_sat(10_000), vec![input], None);
 				let funding_feerate_sat_per_kw = fee_est_c.ret_val.load(atomic::Ordering::Acquire);
 				if let Err(e) = nodes[2].splice_channel(
 					&chan_b_id,
@@ -1958,12 +1946,10 @@ pub fn do_test<Out: Output>(data: &[u8], underlying_out: Out, anchors: bool) {
 					.map(|chan| chan.outbound_capacity_msat)
 					.unwrap();
 				if outbound_capacity_msat >= 20_000_000 {
-					let contribution = SpliceContribution::SpliceOut {
-						outputs: vec![TxOut {
-							value: Amount::from_sat(MAX_STD_OUTPUT_DUST_LIMIT_SATOSHIS),
-							script_pubkey: coinbase_tx.output[0].script_pubkey.clone(),
-						}],
-					};
+					let contribution = SpliceContribution::splice_out(vec![TxOut {
+						value: Amount::from_sat(MAX_STD_OUTPUT_DUST_LIMIT_SATOSHIS),
+						script_pubkey: coinbase_tx.output[0].script_pubkey.clone(),
+					}]);
 					let funding_feerate_sat_per_kw =
 						fee_est_a.ret_val.load(atomic::Ordering::Acquire);
 					if let Err(e) = nodes[0].splice_channel(
@@ -1989,12 +1975,10 @@ pub fn do_test<Out: Output>(data: &[u8], underlying_out: Out, anchors: bool) {
 					.map(|chan| chan.outbound_capacity_msat)
 					.unwrap();
 				if outbound_capacity_msat >= 20_000_000 {
-					let contribution = SpliceContribution::SpliceOut {
-						outputs: vec![TxOut {
-							value: Amount::from_sat(MAX_STD_OUTPUT_DUST_LIMIT_SATOSHIS),
-							script_pubkey: coinbase_tx.output[1].script_pubkey.clone(),
-						}],
-					};
+					let contribution = SpliceContribution::splice_out(vec![TxOut {
+						value: Amount::from_sat(MAX_STD_OUTPUT_DUST_LIMIT_SATOSHIS),
+						script_pubkey: coinbase_tx.output[1].script_pubkey.clone(),
+					}]);
 					let funding_feerate_sat_per_kw =
 						fee_est_b.ret_val.load(atomic::Ordering::Acquire);
 					if let Err(e) = nodes[1].splice_channel(
@@ -2020,12 +2004,10 @@ pub fn do_test<Out: Output>(data: &[u8], underlying_out: Out, anchors: bool) {
 					.map(|chan| chan.outbound_capacity_msat)
 					.unwrap();
 				if outbound_capacity_msat >= 20_000_000 {
-					let contribution = SpliceContribution::SpliceOut {
-						outputs: vec![TxOut {
-							value: Amount::from_sat(MAX_STD_OUTPUT_DUST_LIMIT_SATOSHIS),
-							script_pubkey: coinbase_tx.output[1].script_pubkey.clone(),
-						}],
-					};
+					let contribution = SpliceContribution::splice_out(vec![TxOut {
+						value: Amount::from_sat(MAX_STD_OUTPUT_DUST_LIMIT_SATOSHIS),
+						script_pubkey: coinbase_tx.output[1].script_pubkey.clone(),
+					}]);
 					let funding_feerate_sat_per_kw =
 						fee_est_b.ret_val.load(atomic::Ordering::Acquire);
 					if let Err(e) = nodes[1].splice_channel(
@@ -2051,12 +2033,10 @@ pub fn do_test<Out: Output>(data: &[u8], underlying_out: Out, anchors: bool) {
 					.map(|chan| chan.outbound_capacity_msat)
 					.unwrap();
 				if outbound_capacity_msat >= 20_000_000 {
-					let contribution = SpliceContribution::SpliceOut {
-						outputs: vec![TxOut {
-							value: Amount::from_sat(MAX_STD_OUTPUT_DUST_LIMIT_SATOSHIS),
-							script_pubkey: coinbase_tx.output[2].script_pubkey.clone(),
-						}],
-					};
+					let contribution = SpliceContribution::splice_out(vec![TxOut {
+						value: Amount::from_sat(MAX_STD_OUTPUT_DUST_LIMIT_SATOSHIS),
+						script_pubkey: coinbase_tx.output[2].script_pubkey.clone(),
+					}]);
 					let funding_feerate_sat_per_kw =
 						fee_est_c.ret_val.load(atomic::Ordering::Acquire);
 					if let Err(e) = nodes[2].splice_channel(

--- a/fuzz/src/chanmon_consistency.rs
+++ b/fuzz/src/chanmon_consistency.rs
@@ -554,19 +554,10 @@ fn get_payment_secret_hash(dest: &ChanMan, payment_ctr: &mut u64) -> (PaymentSec
 }
 
 #[inline]
-fn send_noret(
-	source: &ChanMan, dest: &ChanMan, dest_chan_id: u64, amt: u64, payment_ctr: &mut u64,
-) {
-	send_payment(source, dest, dest_chan_id, amt, payment_ctr);
-}
-
-#[inline]
 fn send_payment(
-	source: &ChanMan, dest: &ChanMan, dest_chan_id: u64, amt: u64, payment_ctr: &mut u64,
+	source: &ChanMan, dest: &ChanMan, dest_chan_id: u64, amt: u64, payment_secret: PaymentSecret,
+	payment_hash: PaymentHash, payment_id: PaymentId,
 ) -> bool {
-	let (payment_secret, payment_hash) = get_payment_secret_hash(dest, payment_ctr);
-	let mut payment_id = [0; 32];
-	payment_id[0..8].copy_from_slice(&payment_ctr.to_ne_bytes());
 	let (min_value_sendable, max_value_sendable) = source
 		.list_usable_channels()
 		.iter()
@@ -593,7 +584,6 @@ fn send_payment(
 		route_params: Some(route_params.clone()),
 	};
 	let onion = RecipientOnionFields::secret_only(payment_secret);
-	let payment_id = PaymentId(payment_id);
 	let res = source.send_payment_with_route(route, payment_hash, onion, payment_id);
 	match res {
 		Err(err) => {
@@ -609,21 +599,10 @@ fn send_payment(
 }
 
 #[inline]
-fn send_hop_noret(
-	source: &ChanMan, middle: &ChanMan, middle_scid: u64, dest: &ChanMan, dest_scid: u64, amt: u64,
-	payment_ctr: &mut u64,
-) {
-	send_hop_payment(source, middle, middle_scid, dest, dest_scid, amt, payment_ctr);
-}
-
-#[inline]
 fn send_hop_payment(
 	source: &ChanMan, middle: &ChanMan, middle_scid: u64, dest: &ChanMan, dest_scid: u64, amt: u64,
-	payment_ctr: &mut u64,
+	payment_secret: PaymentSecret, payment_hash: PaymentHash, payment_id: PaymentId,
 ) -> bool {
-	let (payment_secret, payment_hash) = get_payment_secret_hash(dest, payment_ctr);
-	let mut payment_id = [0; 32];
-	payment_id[0..8].copy_from_slice(&payment_ctr.to_ne_bytes());
 	let (min_value_sendable, max_value_sendable) = source
 		.list_usable_channels()
 		.iter()
@@ -662,7 +641,6 @@ fn send_hop_payment(
 		route_params: Some(route_params.clone()),
 	};
 	let onion = RecipientOnionFields::secret_only(payment_secret);
-	let payment_id = PaymentId(payment_id);
 	let res = source.send_payment_with_route(route, payment_hash, onion, payment_id);
 	match res {
 		Err(err) => {
@@ -1634,6 +1612,35 @@ pub fn do_test<Out: Output>(data: &[u8], underlying_out: Out, anchors: bool) {
 			}
 		};
 
+		let send =
+			|source_idx: usize, dest_idx: usize, dest_chan_id, amt, payment_ctr: &mut u64| {
+				let source = &nodes[source_idx];
+				let dest = &nodes[dest_idx];
+				let (secret, hash) = get_payment_secret_hash(dest, payment_ctr);
+				let mut id = PaymentId([0; 32]);
+				id.0[0..8].copy_from_slice(&payment_ctr.to_ne_bytes());
+				send_payment(source, dest, dest_chan_id, amt, secret, hash, id)
+			};
+		let send_noret = |source_idx, dest_idx, dest_chan_id, amt, payment_ctr: &mut u64| {
+			send(source_idx, dest_idx, dest_chan_id, amt, payment_ctr);
+		};
+
+		let send_hop_noret = |source_idx: usize,
+		                      middle_idx: usize,
+		                      middle_scid: u64,
+		                      dest_idx: usize,
+		                      dest_scid: u64,
+		                      amt: u64,
+		                      payment_ctr: &mut u64| {
+			let source = &nodes[source_idx];
+			let middle = &nodes[middle_idx];
+			let dest = &nodes[dest_idx];
+			let (secret, hash) = get_payment_secret_hash(dest, payment_ctr);
+			let mut id = PaymentId([0; 32]);
+			id.0[0..8].copy_from_slice(&payment_ctr.to_ne_bytes());
+			send_hop_payment(source, middle, middle_scid, dest, dest_scid, amt, secret, hash, id);
+		};
+
 		let v = get_slice!(1)[0];
 		out.locked_write(format!("READ A BYTE! HANDLING INPUT {:x}...........\n", v).as_bytes());
 		match v {
@@ -1746,85 +1753,61 @@ pub fn do_test<Out: Output>(data: &[u8], underlying_out: Out, anchors: bool) {
 			0x27 => process_ev_noret!(2, false),
 
 			// 1/10th the channel size:
-			0x30 => send_noret(&nodes[0], &nodes[1], chan_a, 10_000_000, &mut p_ctr),
-			0x31 => send_noret(&nodes[1], &nodes[0], chan_a, 10_000_000, &mut p_ctr),
-			0x32 => send_noret(&nodes[1], &nodes[2], chan_b, 10_000_000, &mut p_ctr),
-			0x33 => send_noret(&nodes[2], &nodes[1], chan_b, 10_000_000, &mut p_ctr),
-			0x34 => send_hop_noret(
-				&nodes[0], &nodes[1], chan_a, &nodes[2], chan_b, 10_000_000, &mut p_ctr,
-			),
-			0x35 => send_hop_noret(
-				&nodes[2], &nodes[1], chan_b, &nodes[0], chan_a, 10_000_000, &mut p_ctr,
-			),
+			0x30 => send_noret(0, 1, chan_a, 10_000_000, &mut p_ctr),
+			0x31 => send_noret(1, 0, chan_a, 10_000_000, &mut p_ctr),
+			0x32 => send_noret(1, 2, chan_b, 10_000_000, &mut p_ctr),
+			0x33 => send_noret(2, 1, chan_b, 10_000_000, &mut p_ctr),
+			0x34 => send_hop_noret(0, 1, chan_a, 2, chan_b, 10_000_000, &mut p_ctr),
+			0x35 => send_hop_noret(2, 1, chan_b, 0, chan_a, 10_000_000, &mut p_ctr),
 
-			0x38 => send_noret(&nodes[0], &nodes[1], chan_a, 1_000_000, &mut p_ctr),
-			0x39 => send_noret(&nodes[1], &nodes[0], chan_a, 1_000_000, &mut p_ctr),
-			0x3a => send_noret(&nodes[1], &nodes[2], chan_b, 1_000_000, &mut p_ctr),
-			0x3b => send_noret(&nodes[2], &nodes[1], chan_b, 1_000_000, &mut p_ctr),
-			0x3c => send_hop_noret(
-				&nodes[0], &nodes[1], chan_a, &nodes[2], chan_b, 1_000_000, &mut p_ctr,
-			),
-			0x3d => send_hop_noret(
-				&nodes[2], &nodes[1], chan_b, &nodes[0], chan_a, 1_000_000, &mut p_ctr,
-			),
+			0x38 => send_noret(0, 1, chan_a, 1_000_000, &mut p_ctr),
+			0x39 => send_noret(1, 0, chan_a, 1_000_000, &mut p_ctr),
+			0x3a => send_noret(1, 2, chan_b, 1_000_000, &mut p_ctr),
+			0x3b => send_noret(2, 1, chan_b, 1_000_000, &mut p_ctr),
+			0x3c => send_hop_noret(0, 1, chan_a, 2, chan_b, 1_000_000, &mut p_ctr),
+			0x3d => send_hop_noret(2, 1, chan_b, 0, chan_a, 1_000_000, &mut p_ctr),
 
-			0x40 => send_noret(&nodes[0], &nodes[1], chan_a, 100_000, &mut p_ctr),
-			0x41 => send_noret(&nodes[1], &nodes[0], chan_a, 100_000, &mut p_ctr),
-			0x42 => send_noret(&nodes[1], &nodes[2], chan_b, 100_000, &mut p_ctr),
-			0x43 => send_noret(&nodes[2], &nodes[1], chan_b, 100_000, &mut p_ctr),
-			0x44 => {
-				send_hop_noret(&nodes[0], &nodes[1], chan_a, &nodes[2], chan_b, 100_000, &mut p_ctr)
-			},
-			0x45 => {
-				send_hop_noret(&nodes[2], &nodes[1], chan_b, &nodes[0], chan_a, 100_000, &mut p_ctr)
-			},
+			0x40 => send_noret(0, 1, chan_a, 100_000, &mut p_ctr),
+			0x41 => send_noret(1, 0, chan_a, 100_000, &mut p_ctr),
+			0x42 => send_noret(1, 2, chan_b, 100_000, &mut p_ctr),
+			0x43 => send_noret(2, 1, chan_b, 100_000, &mut p_ctr),
+			0x44 => send_hop_noret(0, 1, chan_a, 2, chan_b, 100_000, &mut p_ctr),
+			0x45 => send_hop_noret(2, 1, chan_b, 0, chan_a, 100_000, &mut p_ctr),
 
-			0x48 => send_noret(&nodes[0], &nodes[1], chan_a, 10_000, &mut p_ctr),
-			0x49 => send_noret(&nodes[1], &nodes[0], chan_a, 10_000, &mut p_ctr),
-			0x4a => send_noret(&nodes[1], &nodes[2], chan_b, 10_000, &mut p_ctr),
-			0x4b => send_noret(&nodes[2], &nodes[1], chan_b, 10_000, &mut p_ctr),
-			0x4c => {
-				send_hop_noret(&nodes[0], &nodes[1], chan_a, &nodes[2], chan_b, 10_000, &mut p_ctr)
-			},
-			0x4d => {
-				send_hop_noret(&nodes[2], &nodes[1], chan_b, &nodes[0], chan_a, 10_000, &mut p_ctr)
-			},
+			0x48 => send_noret(0, 1, chan_a, 10_000, &mut p_ctr),
+			0x49 => send_noret(1, 0, chan_a, 10_000, &mut p_ctr),
+			0x4a => send_noret(1, 2, chan_b, 10_000, &mut p_ctr),
+			0x4b => send_noret(2, 1, chan_b, 10_000, &mut p_ctr),
+			0x4c => send_hop_noret(0, 1, chan_a, 2, chan_b, 10_000, &mut p_ctr),
+			0x4d => send_hop_noret(2, 1, chan_b, 0, chan_a, 10_000, &mut p_ctr),
 
-			0x50 => send_noret(&nodes[0], &nodes[1], chan_a, 1_000, &mut p_ctr),
-			0x51 => send_noret(&nodes[1], &nodes[0], chan_a, 1_000, &mut p_ctr),
-			0x52 => send_noret(&nodes[1], &nodes[2], chan_b, 1_000, &mut p_ctr),
-			0x53 => send_noret(&nodes[2], &nodes[1], chan_b, 1_000, &mut p_ctr),
-			0x54 => {
-				send_hop_noret(&nodes[0], &nodes[1], chan_a, &nodes[2], chan_b, 1_000, &mut p_ctr)
-			},
-			0x55 => {
-				send_hop_noret(&nodes[2], &nodes[1], chan_b, &nodes[0], chan_a, 1_000, &mut p_ctr)
-			},
+			0x50 => send_noret(0, 1, chan_a, 1_000, &mut p_ctr),
+			0x51 => send_noret(1, 0, chan_a, 1_000, &mut p_ctr),
+			0x52 => send_noret(1, 2, chan_b, 1_000, &mut p_ctr),
+			0x53 => send_noret(2, 1, chan_b, 1_000, &mut p_ctr),
+			0x54 => send_hop_noret(0, 1, chan_a, 2, chan_b, 1_000, &mut p_ctr),
+			0x55 => send_hop_noret(2, 1, chan_b, 0, chan_a, 1_000, &mut p_ctr),
 
-			0x58 => send_noret(&nodes[0], &nodes[1], chan_a, 100, &mut p_ctr),
-			0x59 => send_noret(&nodes[1], &nodes[0], chan_a, 100, &mut p_ctr),
-			0x5a => send_noret(&nodes[1], &nodes[2], chan_b, 100, &mut p_ctr),
-			0x5b => send_noret(&nodes[2], &nodes[1], chan_b, 100, &mut p_ctr),
-			0x5c => {
-				send_hop_noret(&nodes[0], &nodes[1], chan_a, &nodes[2], chan_b, 100, &mut p_ctr)
-			},
-			0x5d => {
-				send_hop_noret(&nodes[2], &nodes[1], chan_b, &nodes[0], chan_a, 100, &mut p_ctr)
-			},
+			0x58 => send_noret(0, 1, chan_a, 100, &mut p_ctr),
+			0x59 => send_noret(1, 0, chan_a, 100, &mut p_ctr),
+			0x5a => send_noret(1, 2, chan_b, 100, &mut p_ctr),
+			0x5b => send_noret(2, 1, chan_b, 100, &mut p_ctr),
+			0x5c => send_hop_noret(0, 1, chan_a, 2, chan_b, 100, &mut p_ctr),
+			0x5d => send_hop_noret(2, 1, chan_b, 0, chan_a, 100, &mut p_ctr),
 
-			0x60 => send_noret(&nodes[0], &nodes[1], chan_a, 10, &mut p_ctr),
-			0x61 => send_noret(&nodes[1], &nodes[0], chan_a, 10, &mut p_ctr),
-			0x62 => send_noret(&nodes[1], &nodes[2], chan_b, 10, &mut p_ctr),
-			0x63 => send_noret(&nodes[2], &nodes[1], chan_b, 10, &mut p_ctr),
-			0x64 => send_hop_noret(&nodes[0], &nodes[1], chan_a, &nodes[2], chan_b, 10, &mut p_ctr),
-			0x65 => send_hop_noret(&nodes[2], &nodes[1], chan_b, &nodes[0], chan_a, 10, &mut p_ctr),
+			0x60 => send_noret(0, 1, chan_a, 10, &mut p_ctr),
+			0x61 => send_noret(1, 0, chan_a, 10, &mut p_ctr),
+			0x62 => send_noret(1, 2, chan_b, 10, &mut p_ctr),
+			0x63 => send_noret(2, 1, chan_b, 10, &mut p_ctr),
+			0x64 => send_hop_noret(0, 1, chan_a, 2, chan_b, 10, &mut p_ctr),
+			0x65 => send_hop_noret(2, 1, chan_b, 0, chan_a, 10, &mut p_ctr),
 
-			0x68 => send_noret(&nodes[0], &nodes[1], chan_a, 1, &mut p_ctr),
-			0x69 => send_noret(&nodes[1], &nodes[0], chan_a, 1, &mut p_ctr),
-			0x6a => send_noret(&nodes[1], &nodes[2], chan_b, 1, &mut p_ctr),
-			0x6b => send_noret(&nodes[2], &nodes[1], chan_b, 1, &mut p_ctr),
-			0x6c => send_hop_noret(&nodes[0], &nodes[1], chan_a, &nodes[2], chan_b, 1, &mut p_ctr),
-			0x6d => send_hop_noret(&nodes[2], &nodes[1], chan_b, &nodes[0], chan_a, 1, &mut p_ctr),
+			0x68 => send_noret(0, 1, chan_a, 1, &mut p_ctr),
+			0x69 => send_noret(1, 0, chan_a, 1, &mut p_ctr),
+			0x6a => send_noret(1, 2, chan_b, 1, &mut p_ctr),
+			0x6b => send_noret(2, 1, chan_b, 1, &mut p_ctr),
+			0x6c => send_hop_noret(0, 1, chan_a, 2, chan_b, 1, &mut p_ctr),
+			0x6d => send_hop_noret(2, 1, chan_b, 0, chan_a, 1, &mut p_ctr),
 
 			0x80 => {
 				let mut max_feerate = last_htlc_clear_fee_a;
@@ -2256,12 +2239,12 @@ pub fn do_test<Out: Output>(data: &[u8], underlying_out: Out, anchors: bool) {
 
 				// Finally, make sure that at least one end of each channel can make a substantial payment
 				assert!(
-					send_payment(&nodes[0], &nodes[1], chan_a, 10_000_000, &mut p_ctr)
-						|| send_payment(&nodes[1], &nodes[0], chan_a, 10_000_000, &mut p_ctr)
+					send(0, 1, chan_a, 10_000_000, &mut p_ctr)
+						|| send(1, 0, chan_a, 10_000_000, &mut p_ctr)
 				);
 				assert!(
-					send_payment(&nodes[1], &nodes[2], chan_b, 10_000_000, &mut p_ctr)
-						|| send_payment(&nodes[2], &nodes[1], chan_b, 10_000_000, &mut p_ctr)
+					send(1, 2, chan_b, 10_000_000, &mut p_ctr)
+						|| send(2, 1, chan_b, 10_000_000, &mut p_ctr)
 				);
 
 				last_htlc_clear_fee_a = fee_est_a.ret_val.load(atomic::Ordering::Acquire);

--- a/fuzz/src/chanmon_consistency.rs
+++ b/fuzz/src/chanmon_consistency.rs
@@ -604,15 +604,15 @@ fn send_payment(
 
 #[inline]
 fn send_hop_noret(
-	source: &ChanMan, middle: &ChanMan, middle_chan_id: u64, dest: &ChanMan, dest_chan_id: u64,
+	source: &ChanMan, middle: &ChanMan, middle_scid: u64, dest: &ChanMan, dest_scid: u64,
 	amt: u64, payment_ctr: &mut u64,
 ) {
-	send_hop_payment(source, middle, middle_chan_id, dest, dest_chan_id, amt, payment_ctr);
+	send_hop_payment(source, middle, middle_scid, dest, dest_scid, amt, payment_ctr);
 }
 
 #[inline]
 fn send_hop_payment(
-	source: &ChanMan, middle: &ChanMan, middle_chan_id: u64, dest: &ChanMan, dest_chan_id: u64,
+	source: &ChanMan, middle: &ChanMan, middle_scid: u64, dest: &ChanMan, dest_scid: u64,
 	amt: u64, payment_ctr: &mut u64,
 ) -> bool {
 	let (payment_secret, payment_hash) = get_payment_secret_hash(dest, payment_ctr);
@@ -621,7 +621,7 @@ fn send_hop_payment(
 	let (min_value_sendable, max_value_sendable) = source
 		.list_usable_channels()
 		.iter()
-		.find(|chan| chan.short_channel_id == Some(middle_chan_id))
+		.find(|chan| chan.short_channel_id == Some(middle_scid))
 		.map(|chan| (chan.next_outbound_htlc_minimum_msat, chan.next_outbound_htlc_limit_msat))
 		.unwrap_or((0, 0));
 	let first_hop_fee = 50_000;
@@ -635,7 +635,7 @@ fn send_hop_payment(
 				RouteHop {
 					pubkey: middle.get_our_node_id(),
 					node_features: middle.node_features(),
-					short_channel_id: middle_chan_id,
+					short_channel_id: middle_scid,
 					channel_features: middle.channel_features(),
 					fee_msat: first_hop_fee,
 					cltv_expiry_delta: 100,
@@ -644,7 +644,7 @@ fn send_hop_payment(
 				RouteHop {
 					pubkey: dest.get_our_node_id(),
 					node_features: dest.node_features(),
-					short_channel_id: dest_chan_id,
+					short_channel_id: dest_scid,
 					channel_features: dest.channel_features(),
 					fee_msat: amt,
 					cltv_expiry_delta: 200,

--- a/fuzz/src/router.rs
+++ b/fuzz/src/router.rs
@@ -89,11 +89,10 @@ impl InputData {
 	}
 }
 
-struct FuzzChainSource<'a, 'b, Out: test_logger::Output> {
+struct FuzzChainSource {
 	input: Arc<InputData>,
-	net_graph: &'a NetworkGraph<&'b test_logger::TestLogger<Out>>,
 }
-impl<Out: test_logger::Output> UtxoLookup for FuzzChainSource<'_, '_, Out> {
+impl UtxoLookup for FuzzChainSource {
 	fn get_utxo(&self, _chain_hash: &ChainHash, _scid: u64, notifier: Arc<Notifier>) -> UtxoResult {
 		let input_slice = self.input.get_slice(2);
 		if input_slice.is_none() {
@@ -109,12 +108,12 @@ impl<Out: test_logger::Output> UtxoLookup for FuzzChainSource<'_, '_, Out> {
 			&[1, _] => UtxoResult::Sync(Err(UtxoLookupError::UnknownTx)),
 			&[2, _] => {
 				let future = UtxoFuture::new(notifier);
-				future.resolve_without_forwarding(self.net_graph, Ok(txo_res));
+				future.resolve(Ok(txo_res));
 				UtxoResult::Async(future.clone())
 			},
 			&[3, _] => {
 				let future = UtxoFuture::new(notifier);
-				future.resolve_without_forwarding(self.net_graph, Err(UtxoLookupError::UnknownTx));
+				future.resolve(Err(UtxoLookupError::UnknownTx));
 				UtxoResult::Async(future.clone())
 			},
 			&[4, _] => {
@@ -198,7 +197,7 @@ pub fn do_test<Out: test_logger::Output>(data: &[u8], out: Out) {
 
 	let our_pubkey = get_pubkey!();
 	let net_graph = NetworkGraph::new(Network::Bitcoin, &logger);
-	let chain_source = FuzzChainSource { input: Arc::clone(&input), net_graph: &net_graph };
+	let chain_source = FuzzChainSource { input: Arc::clone(&input) };
 
 	let mut node_pks = new_hash_map();
 	let mut scid = 42;
@@ -336,9 +335,7 @@ pub fn do_test<Out: test_logger::Output>(data: &[u8], out: Out) {
 				node_pks.insert(get_pubkey_from_node_id!(msg.node_id_1), ());
 				node_pks.insert(get_pubkey_from_node_id!(msg.node_id_2), ());
 				let _ = net_graph
-					.update_channel_from_unsigned_announcement::<&FuzzChainSource<'_, '_, Out>>(
-						&msg, &None,
-					);
+					.update_channel_from_unsigned_announcement::<&FuzzChainSource>(&msg, &None);
 			},
 			2 => {
 				let msg =

--- a/lightning-block-sync/src/gossip.rs
+++ b/lightning-block-sync/src/gossip.rs
@@ -283,7 +283,7 @@ where
 		let pmw = Arc::clone(&self.peer_manager_wake);
 		self.spawn.spawn(async move {
 			let res = Self::retrieve_utxo(source, block_cache, scid).await;
-			fut.resolve(gossiper.network_graph(), &*gossiper, res);
+			fut.resolve(res);
 			(pmw)();
 		});
 		UtxoResult::Async(res)

--- a/lightning-block-sync/src/gossip.rs
+++ b/lightning-block-sync/src/gossip.rs
@@ -9,10 +9,7 @@ use bitcoin::constants::ChainHash;
 use bitcoin::hash_types::BlockHash;
 use bitcoin::transaction::{OutPoint, TxOut};
 
-use lightning::ln::peer_handler::APeerManager;
-use lightning::routing::gossip::{NetworkGraph, P2PGossipSync};
 use lightning::routing::utxo::{UtxoFuture, UtxoLookup, UtxoLookupError, UtxoResult};
-use lightning::util::logger::Logger;
 use lightning::util::native_async::FutureSpawner;
 use lightning::util::wakers::Notifier;
 
@@ -128,46 +125,28 @@ impl<
 /// value of 1024 should more than suffice), and ensure you have sufficient file descriptors
 /// available on both Bitcoin Core and your LDK application for each request to hold its own
 /// connection.
-pub struct GossipVerifier<
-	S: FutureSpawner,
-	Blocks: Deref + Send + Sync + 'static + Clone,
-	L: Deref + Send + Sync + 'static,
-> where
+pub struct GossipVerifier<S: FutureSpawner, Blocks: Deref + Send + Sync + 'static + Clone>
+where
 	Blocks::Target: UtxoSource,
-	L::Target: Logger,
 {
 	source: Blocks,
-	peer_manager_wake: Arc<dyn Fn() + Send + Sync>,
-	gossiper: Arc<P2PGossipSync<Arc<NetworkGraph<L>>, Arc<Self>, L>>,
 	spawn: S,
 	block_cache: Arc<Mutex<VecDeque<(u32, Block)>>>,
 }
 
 const BLOCK_CACHE_SIZE: usize = 5;
 
-impl<S: FutureSpawner, Blocks: Deref + Send + Sync + Clone, L: Deref + Send + Sync>
-	GossipVerifier<S, Blocks, L>
+impl<S: FutureSpawner, Blocks: Deref + Send + Sync + Clone> GossipVerifier<S, Blocks>
 where
 	Blocks::Target: UtxoSource,
-	L::Target: Logger,
 {
-	/// Constructs a new [`GossipVerifier`].
+	/// Constructs a new [`GossipVerifier`] for use in a [`P2PGossipSync`].
 	///
-	/// This is expected to be given to a [`P2PGossipSync`] (initially constructed with `None` for
-	/// the UTXO lookup) via [`P2PGossipSync::add_utxo_lookup`].
-	pub fn new<APM: Deref + Send + Sync + Clone + 'static>(
-		source: Blocks, spawn: S, gossiper: Arc<P2PGossipSync<Arc<NetworkGraph<L>>, Arc<Self>, L>>,
-		peer_manager: APM,
-	) -> Self
-	where
-		APM::Target: APeerManager,
-	{
-		let peer_manager_wake = Arc::new(move || peer_manager.as_ref().process_events());
+	/// [`P2PGossipSync`]: lightning::routing::gossip::P2PGossipSync
+	pub fn new(source: Blocks, spawn: S) -> Self {
 		Self {
 			source,
 			spawn,
-			gossiper,
-			peer_manager_wake,
 			block_cache: Arc::new(Mutex::new(VecDeque::with_capacity(BLOCK_CACHE_SIZE))),
 		}
 	}
@@ -256,11 +235,9 @@ where
 	}
 }
 
-impl<S: FutureSpawner, Blocks: Deref + Send + Sync + Clone, L: Deref + Send + Sync> Deref
-	for GossipVerifier<S, Blocks, L>
+impl<S: FutureSpawner, Blocks: Deref + Send + Sync + Clone> Deref for GossipVerifier<S, Blocks>
 where
 	Blocks::Target: UtxoSource,
-	L::Target: Logger,
 {
 	type Target = Self;
 	fn deref(&self) -> &Self {
@@ -268,23 +245,18 @@ where
 	}
 }
 
-impl<S: FutureSpawner, Blocks: Deref + Send + Sync + Clone, L: Deref + Send + Sync> UtxoLookup
-	for GossipVerifier<S, Blocks, L>
+impl<S: FutureSpawner, Blocks: Deref + Send + Sync + Clone> UtxoLookup for GossipVerifier<S, Blocks>
 where
 	Blocks::Target: UtxoSource,
-	L::Target: Logger,
 {
 	fn get_utxo(&self, _chain_hash: &ChainHash, scid: u64, notifier: Arc<Notifier>) -> UtxoResult {
 		let res = UtxoFuture::new(notifier);
 		let fut = res.clone();
 		let source = self.source.clone();
-		let gossiper = Arc::clone(&self.gossiper);
 		let block_cache = Arc::clone(&self.block_cache);
-		let pmw = Arc::clone(&self.peer_manager_wake);
 		self.spawn.spawn(async move {
 			let res = Self::retrieve_utxo(source, block_cache, scid).await;
 			fut.resolve(res);
-			(pmw)();
 		});
 		UtxoResult::Async(res)
 	}

--- a/lightning-dns-resolver/src/lib.rs
+++ b/lightning-dns-resolver/src/lib.rs
@@ -175,6 +175,7 @@ mod test {
 	use lightning::onion_message::messenger::{
 		AOnionMessenger, Destination, MessageRouter, OnionMessagePath, OnionMessenger,
 	};
+	use lightning::routing::router::DEFAULT_PAYMENT_DUMMY_HOPS;
 	use lightning::sign::{KeysManager, NodeSigner, ReceiveAuthKey, Recipient};
 	use lightning::types::features::InitFeatures;
 	use lightning::types::payment::PaymentHash;
@@ -419,6 +420,12 @@ mod test {
 		let updates = get_htlc_update_msgs(&nodes[0], &payee_id);
 		nodes[1].node.handle_update_add_htlc(payer_id, &updates.update_add_htlcs[0]);
 		do_commitment_signed_dance(&nodes[1], &nodes[0], &updates.commitment_signed, false, false);
+
+		for _ in 0..DEFAULT_PAYMENT_DUMMY_HOPS {
+			assert!(nodes[1].node.needs_pending_htlc_processing());
+			nodes[1].node.process_pending_htlc_forwards();
+		}
+
 		expect_and_process_pending_htlcs(&nodes[1], false);
 
 		let claimable_events = nodes[1].node.get_and_clear_pending_events();

--- a/lightning-dns-resolver/src/lib.rs
+++ b/lightning-dns-resolver/src/lib.rs
@@ -236,6 +236,7 @@ mod test {
 				recipient,
 				local_node_receive_key,
 				context,
+				false,
 				&keys,
 				secp_ctx,
 			)])
@@ -345,6 +346,7 @@ mod test {
 			payer_id,
 			receive_key,
 			query_context,
+			false,
 			&*payer_keys,
 			&secp_ctx,
 		);

--- a/lightning-invoice/src/lib.rs
+++ b/lightning-invoice/src/lib.rs
@@ -54,7 +54,7 @@ use core::time::Duration;
 use serde::{de::Error, Deserialize, Deserializer, Serialize, Serializer};
 
 #[doc(no_inline)]
-pub use lightning_types::payment::PaymentSecret;
+pub use lightning_types::payment::{PaymentHash, PaymentSecret};
 #[doc(no_inline)]
 pub use lightning_types::routing::{RouteHint, RouteHintHop, RoutingFees};
 use lightning_types::string::UntrustedString;
@@ -1460,8 +1460,9 @@ impl Bolt11Invoice {
 	}
 
 	/// Returns the hash to which we will receive the preimage on completion of the payment
-	pub fn payment_hash(&self) -> &sha256::Hash {
-		&self.signed_invoice.payment_hash().expect("checked by constructor").0
+	pub fn payment_hash(&self) -> PaymentHash {
+		let hash = self.signed_invoice.payment_hash().expect("checked by constructor").0;
+		PaymentHash(hash.to_byte_array())
 	}
 
 	/// Return the description or a hash of it for longer ones
@@ -2339,7 +2340,7 @@ mod test {
 				sha256::Hash::from_slice(&[3; 32][..]).unwrap()
 			))
 		);
-		assert_eq!(invoice.payment_hash(), &sha256::Hash::from_slice(&[21; 32][..]).unwrap());
+		assert_eq!(invoice.payment_hash(), PaymentHash([21; 32]));
 		assert_eq!(invoice.payment_secret(), &PaymentSecret([42; 32]));
 
 		let mut expected_features = Bolt11InvoiceFeatures::empty();

--- a/lightning-liquidity/src/lsps5/event.rs
+++ b/lightning-liquidity/src/lsps5/event.rs
@@ -30,9 +30,9 @@ pub enum LSPS5ServiceEvent {
 	/// via their registered webhook.
 	///
 	/// The LSP should send an HTTP POST to the [`url`], using the
-	/// JSON-serialized [`notification`] as the body and including the `headers`.
-	/// If the HTTP request fails, the LSP may implement a retry policy according to its
-	/// implementation preferences.
+	/// JSON-serialized [`notification`] (via [`WebhookNotification::to_request_body`]) as the body
+	/// and including the `headers`.  If the HTTP request fails, the LSP may implement a retry
+	/// policy according to its implementation preferences.
 	///
 	/// The notification is signed using the LSP's node ID to ensure authenticity
 	/// when received by the client. The client verifies this signature using

--- a/lightning-liquidity/src/lsps5/msgs.rs
+++ b/lightning-liquidity/src/lsps5/msgs.rs
@@ -565,6 +565,12 @@ impl WebhookNotification {
 	pub fn onion_message_incoming() -> Self {
 		Self { method: WebhookNotificationMethod::LSPS5OnionMessageIncoming }
 	}
+
+	/// Encodes this notification into JSON which can be sent as the body of an HTTP request to
+	/// deliver the notification.
+	pub fn to_request_body(&self) -> String {
+		serde_json::to_string(self).unwrap()
+	}
 }
 
 impl Serialize for WebhookNotification {

--- a/lightning-liquidity/tests/lsps2_integration_tests.rs
+++ b/lightning-liquidity/tests/lsps2_integration_tests.rs
@@ -1211,7 +1211,7 @@ fn client_trusts_lsp_end_to_end_test() {
 		.node
 		.pay_for_bolt11_invoice(
 			&invoice,
-			PaymentId(invoice.payment_hash().to_byte_array()),
+			PaymentId(invoice.payment_hash().0),
 			None,
 			Default::default(),
 			Retry::Attempts(3),
@@ -1684,7 +1684,7 @@ fn late_payment_forwarded_and_safe_after_force_close_does_not_broadcast() {
 		.node
 		.pay_for_bolt11_invoice(
 			&invoice,
-			PaymentId(invoice.payment_hash().to_byte_array()),
+			PaymentId(invoice.payment_hash().0),
 			None,
 			Default::default(),
 			Retry::Attempts(3),
@@ -1714,7 +1714,7 @@ fn late_payment_forwarded_and_safe_after_force_close_does_not_broadcast() {
 					*requested_next_hop_scid,
 					*intercept_id,
 					*expected_outbound_amount_msat,
-					PaymentHash(invoice.payment_hash().to_byte_array()),
+					invoice.payment_hash(),
 				)
 				.unwrap();
 		},
@@ -1875,7 +1875,7 @@ fn htlc_timeout_before_client_claim_results_in_handling_failed() {
 		.node
 		.pay_for_bolt11_invoice(
 			&invoice,
-			PaymentId(invoice.payment_hash().to_byte_array()),
+			PaymentId(invoice.payment_hash().0),
 			None,
 			Default::default(),
 			Retry::Attempts(3),
@@ -1905,7 +1905,7 @@ fn htlc_timeout_before_client_claim_results_in_handling_failed() {
 					*requested_next_hop_scid,
 					*intercept_id,
 					*expected_outbound_amount_msat,
-					PaymentHash(invoice.payment_hash().to_byte_array()),
+					invoice.payment_hash(),
 				)
 				.unwrap();
 		},
@@ -1984,7 +1984,7 @@ fn htlc_timeout_before_client_claim_results_in_handling_failed() {
 	match &client_events[0] {
 		Event::HTLCHandlingFailed { failure_type, .. } => match failure_type {
 			lightning::events::HTLCHandlingFailureType::Receive { payment_hash } => {
-				assert_eq!(*payment_hash, PaymentHash(invoice.payment_hash().to_byte_array()));
+				assert_eq!(*payment_hash, invoice.payment_hash());
 			},
 			_ => panic!("Unexpected failure_type: {:?}", failure_type),
 		},
@@ -2212,7 +2212,7 @@ fn client_trusts_lsp_partial_fee_does_not_trigger_broadcast() {
 		.node
 		.pay_for_bolt11_invoice(
 			&invoice,
-			PaymentId(invoice.payment_hash().to_byte_array()),
+			PaymentId(invoice.payment_hash().0),
 			None,
 			Default::default(),
 			Retry::Attempts(3),

--- a/lightning-net-tokio/Cargo.toml
+++ b/lightning-net-tokio/Cargo.toml
@@ -19,7 +19,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 [dependencies]
 bitcoin = "0.32.2"
 lightning = { version = "0.3.0", path = "../lightning" }
-tokio = { version = "1.35", features = [ "rt", "sync", "net", "time" ] }
+tokio = { version = "1.35", features = [ "rt", "sync", "net", "time", "io-util" ] }
 
 [dev-dependencies]
 tokio = { version = "1.35", features = [ "macros", "rt", "rt-multi-thread", "sync", "net", "time" ] }

--- a/lightning-tests/src/upgrade_downgrade_tests.rs
+++ b/lightning-tests/src/upgrade_downgrade_tests.rs
@@ -451,12 +451,10 @@ fn do_test_0_1_htlc_forward_after_splice(fail_htlc: bool) {
 	reconnect_b_c_args.send_announcement_sigs = (true, true);
 	reconnect_nodes(reconnect_b_c_args);
 
-	let contribution = SpliceContribution::SpliceOut {
-		outputs: vec![TxOut {
-			value: Amount::from_sat(1_000),
-			script_pubkey: nodes[0].wallet_source.get_change_script().unwrap(),
-		}],
-	};
+	let contribution = SpliceContribution::splice_out(vec![TxOut {
+		value: Amount::from_sat(1_000),
+		script_pubkey: nodes[0].wallet_source.get_change_script().unwrap(),
+	}]);
 	let splice_tx = splice_channel(&nodes[0], &nodes[1], ChannelId(chan_id_bytes_a), contribution);
 	for node in nodes.iter() {
 		mine_transaction(node, &splice_tx);

--- a/lightning/src/blinded_path/message.rs
+++ b/lightning/src/blinded_path/message.rs
@@ -416,28 +416,45 @@ pub enum OffersContext {
 		/// Useful to timeout async recipients that are no longer supported as clients.
 		path_absolute_expiry: Duration,
 	},
-	/// Context used by a [`BlindedMessagePath`] within a [`Refund`] or as a reply path for an
-	/// [`InvoiceRequest`].
+	/// Context used by a [`BlindedMessagePath`] within a [`Refund`].
 	///
 	/// This variant is intended to be received when handling a [`Bolt12Invoice`] or an
 	/// [`InvoiceError`].
 	///
 	/// [`Refund`]: crate::offers::refund::Refund
-	/// [`InvoiceRequest`]: crate::offers::invoice_request::InvoiceRequest
 	/// [`Bolt12Invoice`]: crate::offers::invoice::Bolt12Invoice
 	/// [`InvoiceError`]: crate::offers::invoice_error::InvoiceError
-	OutboundPayment {
-		/// Payment ID used when creating a [`Refund`] or [`InvoiceRequest`].
+	OutboundPaymentForRefund {
+		/// Payment ID used when creating a [`Refund`].
 		///
 		/// [`Refund`]: crate::offers::refund::Refund
-		/// [`InvoiceRequest`]: crate::offers::invoice_request::InvoiceRequest
 		payment_id: PaymentId,
 
-		/// A nonce used for authenticating that a [`Bolt12Invoice`] is for a valid [`Refund`] or
-		/// [`InvoiceRequest`] and for deriving their signing keys.
+		/// A nonce used for authenticating that a [`Bolt12Invoice`] is for a valid [`Refund`] and
+		/// for deriving its signing keys.
 		///
 		/// [`Bolt12Invoice`]: crate::offers::invoice::Bolt12Invoice
 		/// [`Refund`]: crate::offers::refund::Refund
+		nonce: Nonce,
+	},
+	/// Context used by a [`BlindedMessagePath`] as a reply path for an [`InvoiceRequest`].
+	///
+	/// This variant is intended to be received when handling a [`Bolt12Invoice`] or an
+	/// [`InvoiceError`].
+	///
+	/// [`InvoiceRequest`]: crate::offers::invoice_request::InvoiceRequest
+	/// [`Bolt12Invoice`]: crate::offers::invoice::Bolt12Invoice
+	/// [`InvoiceError`]: crate::offers::invoice_error::InvoiceError
+	OutboundPaymentForOffer {
+		/// Payment ID used when creating an [`InvoiceRequest`].
+		///
+		/// [`InvoiceRequest`]: crate::offers::invoice_request::InvoiceRequest
+		payment_id: PaymentId,
+
+		/// A nonce used for authenticating that a [`Bolt12Invoice`] is for a valid
+		/// [`InvoiceRequest`] and for deriving its signing keys.
+		///
+		/// [`Bolt12Invoice`]: crate::offers::invoice::Bolt12Invoice
 		/// [`InvoiceRequest`]: crate::offers::invoice_request::InvoiceRequest
 		nonce: Nonce,
 	},
@@ -619,7 +636,7 @@ impl_writeable_tlv_based_enum!(OffersContext,
 	(0, InvoiceRequest) => {
 		(0, nonce, required),
 	},
-	(1, OutboundPayment) => {
+	(1, OutboundPaymentForRefund) => {
 		(0, payment_id, required),
 		(1, nonce, required),
 	},
@@ -630,6 +647,10 @@ impl_writeable_tlv_based_enum!(OffersContext,
 		(0, recipient_id, required),
 		(2, invoice_slot, required),
 		(4, path_absolute_expiry, required),
+	},
+	(4, OutboundPaymentForOffer) => {
+		(0, payment_id, required),
+		(1, nonce, required),
 	},
 );
 

--- a/lightning/src/blinded_path/message.rs
+++ b/lightning/src/blinded_path/message.rs
@@ -54,21 +54,38 @@ impl Readable for BlindedMessagePath {
 
 impl BlindedMessagePath {
 	/// Create a one-hop blinded path for a message.
+	///
+	/// `compact_padding` selects between space-inefficient padding which better hides contents and
+	/// a space-constrained padding which does very little to hide the contents, especially for the
+	/// last hop. It should only be set when the blinded path needs to be as compact as possible.
 	pub fn one_hop<ES: Deref, T: secp256k1::Signing + secp256k1::Verification>(
 		recipient_node_id: PublicKey, local_node_receive_key: ReceiveAuthKey,
-		context: MessageContext, entropy_source: ES, secp_ctx: &Secp256k1<T>,
+		context: MessageContext, compact_padding: bool, entropy_source: ES,
+		secp_ctx: &Secp256k1<T>,
 	) -> Self
 	where
 		ES::Target: EntropySource,
 	{
-		Self::new(&[], recipient_node_id, local_node_receive_key, context, entropy_source, secp_ctx)
+		Self::new(
+			&[],
+			recipient_node_id,
+			local_node_receive_key,
+			context,
+			compact_padding,
+			entropy_source,
+			secp_ctx,
+		)
 	}
 
 	/// Create a path for an onion message, to be forwarded along `node_pks`.
+	///
+	/// `compact_padding` selects between space-inefficient padding which better hides contents and
+	/// a space-constrained padding which does very little to hide the contents, especially for the
+	/// last hop. It should only be set when the blinded path needs to be as compact as possible.
 	pub fn new<ES: Deref, T: secp256k1::Signing + secp256k1::Verification>(
 		intermediate_nodes: &[MessageForwardNode], recipient_node_id: PublicKey,
-		local_node_receive_key: ReceiveAuthKey, context: MessageContext, entropy_source: ES,
-		secp_ctx: &Secp256k1<T>,
+		local_node_receive_key: ReceiveAuthKey, context: MessageContext, compact_padding: bool,
+		entropy_source: ES, secp_ctx: &Secp256k1<T>,
 	) -> Self
 	where
 		ES::Target: EntropySource,
@@ -79,6 +96,7 @@ impl BlindedMessagePath {
 			0,
 			local_node_receive_key,
 			context,
+			compact_padding,
 			entropy_source,
 			secp_ctx,
 		)
@@ -86,12 +104,15 @@ impl BlindedMessagePath {
 
 	/// Same as [`BlindedMessagePath::new`], but allows specifying a number of dummy hops.
 	///
-	/// Note:
-	/// At most [`MAX_DUMMY_HOPS_COUNT`] dummy hops can be added to the blinded path.
+	/// `compact_padding` selects between space-inefficient padding which better hides contents and
+	/// a space-constrained padding which does very little to hide the contents, especially for the
+	/// last hop. It should only be set when the blinded path needs to be as compact as possible.
+	///
+	/// Note: At most [`MAX_DUMMY_HOPS_COUNT`] dummy hops can be added to the blinded path.
 	pub fn new_with_dummy_hops<ES: Deref, T: secp256k1::Signing + secp256k1::Verification>(
 		intermediate_nodes: &[MessageForwardNode], recipient_node_id: PublicKey,
 		dummy_hop_count: usize, local_node_receive_key: ReceiveAuthKey, context: MessageContext,
-		entropy_source: ES, secp_ctx: &Secp256k1<T>,
+		compact_padding: bool, entropy_source: ES, secp_ctx: &Secp256k1<T>,
 	) -> Self
 	where
 		ES::Target: EntropySource,
@@ -114,6 +135,7 @@ impl BlindedMessagePath {
 				context,
 				&blinding_secret,
 				local_node_receive_key,
+				compact_padding,
 			),
 		})
 	}
@@ -714,7 +736,7 @@ pub const MAX_DUMMY_HOPS_COUNT: usize = 10;
 pub(super) fn blinded_hops<T: secp256k1::Signing + secp256k1::Verification>(
 	secp_ctx: &Secp256k1<T>, intermediate_nodes: &[MessageForwardNode],
 	recipient_node_id: PublicKey, dummy_hop_count: usize, context: MessageContext,
-	session_priv: &SecretKey, local_node_receive_key: ReceiveAuthKey,
+	session_priv: &SecretKey, local_node_receive_key: ReceiveAuthKey, compact_padding: bool,
 ) -> Vec<BlindedHop> {
 	let dummy_count = cmp::min(dummy_hop_count, MAX_DUMMY_HOPS_COUNT);
 	let pks = intermediate_nodes
@@ -724,9 +746,8 @@ pub(super) fn blinded_hops<T: secp256k1::Signing + secp256k1::Verification>(
 			core::iter::repeat((recipient_node_id, Some(local_node_receive_key))).take(dummy_count),
 		)
 		.chain(core::iter::once((recipient_node_id, Some(local_node_receive_key))));
-	let is_compact = intermediate_nodes.iter().any(|node| node.short_channel_id.is_some());
 
-	let tlvs = pks
+	let intermediate_tlvs = pks
 		.clone()
 		.skip(1) // The first node's TLVs contains the next node's pubkey
 		.zip(intermediate_nodes.iter().map(|node| node.short_channel_id))
@@ -737,18 +758,43 @@ pub(super) fn blinded_hops<T: secp256k1::Signing + secp256k1::Verification>(
 		.map(|next_hop| {
 			ControlTlvs::Forward(ForwardTlvs { next_hop, next_blinding_override: None })
 		})
-		.chain((0..dummy_count).map(|_| ControlTlvs::Dummy))
-		.chain(core::iter::once(ControlTlvs::Receive(ReceiveTlvs { context: Some(context) })));
+		.chain((0..dummy_count).map(|_| ControlTlvs::Dummy));
 
-	if is_compact {
-		let path = pks.zip(tlvs);
-		utils::construct_blinded_hops(secp_ctx, path, session_priv)
+	let max_intermediate_len =
+		intermediate_tlvs.clone().map(|tlvs| tlvs.serialized_length()).max().unwrap_or(0);
+	let have_intermediate_one_byte_smaller =
+		intermediate_tlvs.clone().any(|tlvs| tlvs.serialized_length() == max_intermediate_len - 1);
+
+	let round_off = if compact_padding {
+		// We can only pad by a minimum of two bytes (we can only go from no-TLV to a type + length
+		// byte). Thus, if there are any intermediate hops that need to be padded by exactly one
+		// byte, we have to instead pad everything by two.
+		if have_intermediate_one_byte_smaller {
+			max_intermediate_len + 2
+		} else {
+			max_intermediate_len
+		}
 	} else {
-		let path =
-			pks.zip(tlvs.map(|tlv| BlindedPathWithPadding {
-				tlvs: tlv,
-				round_off: MESSAGE_PADDING_ROUND_OFF,
-			}));
-		utils::construct_blinded_hops(secp_ctx, path, session_priv)
-	}
+		MESSAGE_PADDING_ROUND_OFF
+	};
+
+	let tlvs = intermediate_tlvs
+		.map(|tlvs| {
+			let res = BlindedPathWithPadding { tlvs, round_off };
+			if compact_padding {
+				debug_assert_eq!(res.serialized_length(), max_intermediate_len);
+			} else {
+				// We don't currently ever push extra fields to intermediate hops, so they should
+				// never go over `MESSAGE_PADDING_ROUND_OFF`.
+				debug_assert_eq!(res.serialized_length(), MESSAGE_PADDING_ROUND_OFF);
+			}
+			res
+		})
+		.chain(core::iter::once(BlindedPathWithPadding {
+			tlvs: ControlTlvs::Receive(ReceiveTlvs { context: Some(context) }),
+			round_off: if compact_padding { 0 } else { MESSAGE_PADDING_ROUND_OFF },
+		}));
+
+	let path = pks.zip(tlvs);
+	utils::construct_blinded_hops(secp_ctx, path, session_priv)
 }

--- a/lightning/src/blinded_path/utils.rs
+++ b/lightning/src/blinded_path/utils.rs
@@ -256,9 +256,12 @@ impl<T: Writeable> Writeable for BlindedPathWithPadding<T> {
 		let tlv_length = self.tlvs.serialized_length();
 		let total_length = tlv_length + TLV_OVERHEAD;
 
-		let padding_length = total_length.div_ceil(self.round_off) * self.round_off - total_length;
-
-		let padding = Some(BlindedPathPadding::new(padding_length));
+		let padding = if self.round_off == 0 || tlv_length % self.round_off == 0 {
+			None
+		} else {
+			let length = total_length.div_ceil(self.round_off) * self.round_off - total_length;
+			Some(BlindedPathPadding::new(length))
+		};
 
 		encode_tlv_stream!(writer, {
 			(1, padding, option),

--- a/lightning/src/events/mod.rs
+++ b/lightning/src/events/mod.rs
@@ -30,6 +30,7 @@ use crate::ln::onion_utils::LocalHTLCFailureReason;
 use crate::ln::types::ChannelId;
 use crate::offers::invoice::Bolt12Invoice;
 use crate::offers::invoice_request::InvoiceRequest;
+use crate::offers::nonce::Nonce;
 use crate::offers::static_invoice::StaticInvoice;
 use crate::onion_message::messenger::Responder;
 use crate::routing::gossip::NetworkUpdate;
@@ -1065,6 +1066,17 @@ pub enum Event {
 		///
 		/// [`StaticInvoice`]: crate::offers::static_invoice::StaticInvoice
 		bolt12_invoice: Option<PaidBolt12Invoice>,
+		/// The [`Nonce`] used when the BOLT 12 [`InvoiceRequest`] was created for the corresponding
+		/// [`Offer`] or [`Refund`].
+		///
+		/// This is needed to build a payer proof, as it allows deriving the signing keys used for
+		/// the [`InvoiceRequest`]. `None` for non-BOLT 12 payments or for payments initiated on
+		/// LDK versions prior to 0.2.
+		///
+		/// [`InvoiceRequest`]: crate::offers::invoice_request::InvoiceRequest
+		/// [`Offer`]: crate::offers::offer::Offer
+		/// [`Refund`]: crate::offers::refund::Refund
+		payment_nonce: Option<Nonce>,
 	},
 	/// Indicates an outbound payment failed. Individual [`Event::PaymentPathFailed`] events
 	/// provide failure information for each path attempt in the payment, including retries.
@@ -1958,6 +1970,7 @@ impl Writeable for Event {
 				ref amount_msat,
 				ref fee_paid_msat,
 				ref bolt12_invoice,
+				ref payment_nonce,
 			} => {
 				2u8.write(writer)?;
 				write_tlv_fields!(writer, {
@@ -1967,6 +1980,7 @@ impl Writeable for Event {
 					(5, fee_paid_msat, option),
 					(7, amount_msat, option),
 					(9, bolt12_invoice, option),
+					(11, payment_nonce, option),
 				});
 			},
 			&Event::PaymentPathFailed {
@@ -2433,6 +2447,7 @@ impl MaybeReadable for Event {
 					let mut amount_msat = None;
 					let mut fee_paid_msat = None;
 					let mut bolt12_invoice = None;
+					let mut payment_nonce = None;
 					read_tlv_fields!(reader, {
 						(0, payment_preimage, required),
 						(1, payment_hash, option),
@@ -2440,6 +2455,7 @@ impl MaybeReadable for Event {
 						(5, fee_paid_msat, option),
 						(7, amount_msat, option),
 						(9, bolt12_invoice, option),
+						(11, payment_nonce, option),
 					});
 					if payment_hash.is_none() {
 						payment_hash = Some(PaymentHash(
@@ -2453,6 +2469,7 @@ impl MaybeReadable for Event {
 						amount_msat,
 						fee_paid_msat,
 						bolt12_invoice,
+						payment_nonce,
 					}))
 				};
 				f()

--- a/lightning/src/ln/accountable_tests.rs
+++ b/lightning/src/ln/accountable_tests.rs
@@ -1,0 +1,102 @@
+// This file is Copyright its original authors, visible in version control
+// history.
+//
+// This file is licensed under the Apache License, Version 2.0 <LICENSE-APACHE
+// or http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your option.
+// You may not use this file except in accordance with one or both of these
+// licenses.
+
+//! Tests for verifying the correct relay of accountable signals between nodes.
+
+use crate::ln::channelmanager::{
+	HTLCForwardInfo, PaymentId, PendingAddHTLCInfo, PendingHTLCInfo, RecipientOnionFields, Retry,
+};
+use crate::ln::functional_test_utils::*;
+use crate::ln::msgs::ChannelMessageHandler;
+use crate::routing::router::{PaymentParameters, RouteParameters};
+
+fn test_accountable_forwarding_with_override(
+	override_accountable: Option<bool>, expected_forwarded: bool,
+) {
+	let chanmon_cfgs = create_chanmon_cfgs(3);
+	let node_cfgs = create_node_cfgs(3, &chanmon_cfgs);
+	let node_chanmgrs = create_node_chanmgrs(3, &node_cfgs, &[None, None, None]);
+	let nodes = create_network(3, &node_cfgs, &node_chanmgrs);
+
+	let _chan_ab = create_announced_chan_between_nodes(&nodes, 0, 1);
+	let _chan_bc = create_announced_chan_between_nodes(&nodes, 1, 2);
+
+	let (payment_preimage, payment_hash, payment_secret) = get_payment_preimage_hash!(nodes[2]);
+	let route_params = RouteParameters::from_payment_params_and_value(
+		PaymentParameters::from_node_id(nodes[2].node.get_our_node_id(), TEST_FINAL_CLTV),
+		100_000,
+	);
+	let onion_fields = RecipientOnionFields::secret_only(payment_secret);
+	let payment_id = PaymentId(payment_hash.0);
+	nodes[0]
+		.node
+		.send_payment(payment_hash, onion_fields, payment_id, route_params, Retry::Attempts(0))
+		.unwrap();
+	check_added_monitors(&nodes[0], 1);
+
+	let updates_ab = get_htlc_update_msgs(&nodes[0], &nodes[1].node.get_our_node_id());
+	assert_eq!(updates_ab.update_add_htlcs.len(), 1);
+	let mut htlc_ab = updates_ab.update_add_htlcs[0].clone();
+	assert_eq!(htlc_ab.accountable, Some(false));
+
+	// Override accountable value if requested
+	if let Some(override_value) = override_accountable {
+		htlc_ab.accountable = Some(override_value);
+	}
+
+	nodes[1].node.handle_update_add_htlc(nodes[0].node.get_our_node_id(), &htlc_ab);
+	do_commitment_signed_dance(&nodes[1], &nodes[0], &updates_ab.commitment_signed, false, false);
+	expect_and_process_pending_htlcs(&nodes[1], false);
+	check_added_monitors(&nodes[1], 1);
+
+	let updates_bc = get_htlc_update_msgs(&nodes[1], &nodes[2].node.get_our_node_id());
+	assert_eq!(updates_bc.update_add_htlcs.len(), 1);
+	let htlc_bc = &updates_bc.update_add_htlcs[0];
+	assert_eq!(
+		htlc_bc.accountable,
+		Some(expected_forwarded),
+		"B -> C should have accountable = {:?}",
+		expected_forwarded
+	);
+
+	nodes[2].node.handle_update_add_htlc(nodes[1].node.get_our_node_id(), htlc_bc);
+	do_commitment_signed_dance(&nodes[2], &nodes[1], &updates_bc.commitment_signed, false, false);
+
+	// Accountable signal is not surfaced in PaymentClaimable, so we do our next-best and check
+	// that the received htlcs that will be processed has the signal set as we expect. We manually
+	// process pending update adds so that we can access the htlc in forward_htlcs.
+	nodes[2].node.test_process_pending_update_add_htlcs();
+	{
+		let fwds_lock = nodes[2].node.forward_htlcs.lock().unwrap();
+		let recvs = fwds_lock.get(&0).unwrap();
+		assert_eq!(recvs.len(), 1);
+		match recvs[0] {
+			HTLCForwardInfo::AddHTLC(PendingAddHTLCInfo {
+				forward_info: PendingHTLCInfo { incoming_accountable, .. },
+				..
+			}) => {
+				assert_eq!(incoming_accountable, expected_forwarded)
+			},
+			_ => panic!("Unexpected forward"),
+		}
+	}
+
+	expect_and_process_pending_htlcs(&nodes[2], false);
+	check_added_monitors(&nodes[2], 0);
+	expect_payment_claimable!(nodes[2], payment_hash, payment_secret, 100_000);
+	claim_payment(&nodes[0], &[&nodes[1], &nodes[2]], payment_preimage);
+}
+
+#[test]
+fn test_accountable_signal() {
+	// Tests forwarding of accountable signal for various incoming signal values.
+	test_accountable_forwarding_with_override(None, false);
+	test_accountable_forwarding_with_override(Some(true), true);
+	test_accountable_forwarding_with_override(Some(false), false);
+}

--- a/lightning/src/ln/async_payments_tests.rs
+++ b/lightning/src/ln/async_payments_tests.rs
@@ -10,8 +10,8 @@
 use crate::blinded_path::message::{
 	BlindedMessagePath, MessageContext, NextMessageHop, OffersContext,
 };
-use crate::blinded_path::payment::PaymentContext;
 use crate::blinded_path::payment::{AsyncBolt12OfferContext, BlindedPaymentTlvs};
+use crate::blinded_path::payment::{DummyTlvs, PaymentContext};
 use crate::chain::channelmonitor::{HTLC_FAIL_BACK_BUFFER, LATENCY_GRACE_PERIOD_BLOCKS};
 use crate::events::{
 	Event, EventsProvider, HTLCHandlingFailureReason, HTLCHandlingFailureType, PaidBolt12Invoice,
@@ -55,7 +55,7 @@ use crate::onion_message::messenger::{
 use crate::onion_message::offers::OffersMessage;
 use crate::onion_message::packet::ParsedOnionMessageContents;
 use crate::prelude::*;
-use crate::routing::router::{Payee, PaymentParameters};
+use crate::routing::router::{Payee, PaymentParameters, DEFAULT_PAYMENT_DUMMY_HOPS};
 use crate::sign::NodeSigner;
 use crate::sync::Mutex;
 use crate::types::features::Bolt12InvoiceFeatures;
@@ -984,7 +984,8 @@ fn ignore_duplicate_invoice() {
 	check_added_monitors!(sender, 1);
 
 	let route: &[&[&Node]] = &[&[always_online_node, async_recipient]];
-	let args = PassAlongPathArgs::new(sender, route[0], amt_msat, payment_hash, ev);
+	let args = PassAlongPathArgs::new(sender, route[0], amt_msat, payment_hash, ev)
+		.with_dummy_tlvs(&[DummyTlvs::default(); DEFAULT_PAYMENT_DUMMY_HOPS]);
 	let claimable_ev = do_pass_along_path(args).unwrap();
 	let keysend_preimage = extract_payment_preimage(&claimable_ev);
 	let (res, _) =
@@ -1063,7 +1064,8 @@ fn ignore_duplicate_invoice() {
 	check_added_monitors!(sender, 1);
 
 	let args = PassAlongPathArgs::new(sender, route[0], amt_msat, payment_hash, ev)
-		.without_clearing_recipient_events();
+		.without_clearing_recipient_events()
+		.with_dummy_tlvs(&[DummyTlvs::default(); DEFAULT_PAYMENT_DUMMY_HOPS]);
 	do_pass_along_path(args);
 
 	let payment_preimage = match get_event!(async_recipient, Event::PaymentClaimable) {
@@ -1138,7 +1140,8 @@ fn async_receive_flow_success() {
 	assert!(nodes[0].node.get_and_clear_pending_msg_events().is_empty());
 
 	let route: &[&[&Node]] = &[&[&nodes[1], &nodes[2]]];
-	let args = PassAlongPathArgs::new(&nodes[0], route[0], amt_msat, payment_hash, ev);
+	let args = PassAlongPathArgs::new(&nodes[0], route[0], amt_msat, payment_hash, ev)
+		.with_dummy_tlvs(&[DummyTlvs::default(); DEFAULT_PAYMENT_DUMMY_HOPS]);
 	let claimable_ev = do_pass_along_path(args).unwrap();
 	let keysend_preimage = extract_payment_preimage(&claimable_ev);
 	let (res, _) =
@@ -1375,11 +1378,13 @@ fn async_receive_mpp() {
 	};
 
 	let args = PassAlongPathArgs::new(&nodes[0], expected_route[0], amt_msat, payment_hash, ev)
-		.without_claimable_event();
+		.without_claimable_event()
+		.with_dummy_tlvs(&[DummyTlvs::default(); DEFAULT_PAYMENT_DUMMY_HOPS]);
 	do_pass_along_path(args);
 
 	let ev = remove_first_msg_event_to_node(&nodes[2].node.get_our_node_id(), &mut events);
-	let args = PassAlongPathArgs::new(&nodes[0], expected_route[1], amt_msat, payment_hash, ev);
+	let args = PassAlongPathArgs::new(&nodes[0], expected_route[1], amt_msat, payment_hash, ev)
+		.with_dummy_tlvs(&[DummyTlvs::default(); DEFAULT_PAYMENT_DUMMY_HOPS]);
 	let claimable_ev = do_pass_along_path(args).unwrap();
 	let keysend_preimage = match claimable_ev {
 		Event::PaymentClaimable {
@@ -1497,7 +1502,8 @@ fn amount_doesnt_match_invreq() {
 	let route: &[&[&Node]] = &[&[&nodes[1], &nodes[3]]];
 	let args = PassAlongPathArgs::new(&nodes[0], route[0], amt_msat, payment_hash, ev)
 		.without_claimable_event()
-		.expect_failure(HTLCHandlingFailureType::Receive { payment_hash });
+		.expect_failure(HTLCHandlingFailureType::Receive { payment_hash })
+		.with_dummy_tlvs(&[DummyTlvs::default(); DEFAULT_PAYMENT_DUMMY_HOPS]);
 	do_pass_along_path(args);
 
 	// Modify the invoice request stored in our outbounds to be the correct one, to make sure the
@@ -1521,7 +1527,8 @@ fn amount_doesnt_match_invreq() {
 				ev, MessageSendEvent::UpdateHTLCs { ref updates, .. } if updates.update_add_htlcs.len() == 1));
 	check_added_monitors!(nodes[0], 1);
 	let route: &[&[&Node]] = &[&[&nodes[2], &nodes[3]]];
-	let args = PassAlongPathArgs::new(&nodes[0], route[0], amt_msat, payment_hash, ev);
+	let args = PassAlongPathArgs::new(&nodes[0], route[0], amt_msat, payment_hash, ev)
+		.with_dummy_tlvs(&[DummyTlvs::default(); DEFAULT_PAYMENT_DUMMY_HOPS]);
 	let claimable_ev = do_pass_along_path(args).unwrap();
 	let keysend_preimage = extract_payment_preimage(&claimable_ev);
 	claim_payment_along_route(ClaimAlongRouteArgs::new(&nodes[0], route, keysend_preimage));
@@ -1712,7 +1719,8 @@ fn invalid_async_receive_with_retry<F1, F2>(
 	let payment_hash = extract_payment_hash(&ev);
 
 	let route: &[&[&Node]] = &[&[&nodes[1], &nodes[2]]];
-	let args = PassAlongPathArgs::new(&nodes[0], route[0], amt_msat, payment_hash, ev);
+	let args = PassAlongPathArgs::new(&nodes[0], route[0], amt_msat, payment_hash, ev)
+		.with_dummy_tlvs(&[DummyTlvs::default(); DEFAULT_PAYMENT_DUMMY_HOPS]);
 	do_pass_along_path(args);
 
 	// Fail the HTLC backwards to enable us to more easily modify the now-Retryable outbound to test
@@ -1739,7 +1747,8 @@ fn invalid_async_receive_with_retry<F1, F2>(
 	let route: &[&[&Node]] = &[&[&nodes[1], &nodes[2]]];
 	let args = PassAlongPathArgs::new(&nodes[0], route[0], amt_msat, payment_hash, ev)
 		.without_claimable_event()
-		.expect_failure(HTLCHandlingFailureType::Receive { payment_hash });
+		.expect_failure(HTLCHandlingFailureType::Receive { payment_hash })
+		.with_dummy_tlvs(&[DummyTlvs::default(); DEFAULT_PAYMENT_DUMMY_HOPS]);
 	do_pass_along_path(args);
 	fail_blinded_htlc_backwards(payment_hash, 1, &[&nodes[0], &nodes[1], &nodes[2]], true);
 
@@ -1751,7 +1760,8 @@ fn invalid_async_receive_with_retry<F1, F2>(
 	let mut ev = remove_first_msg_event_to_node(&nodes[1].node.get_our_node_id(), &mut events);
 	check_added_monitors!(nodes[0], 1);
 	let route: &[&[&Node]] = &[&[&nodes[1], &nodes[2]]];
-	let args = PassAlongPathArgs::new(&nodes[0], route[0], amt_msat, payment_hash, ev);
+	let args = PassAlongPathArgs::new(&nodes[0], route[0], amt_msat, payment_hash, ev)
+		.with_dummy_tlvs(&[DummyTlvs::default(); DEFAULT_PAYMENT_DUMMY_HOPS]);
 	let claimable_ev = do_pass_along_path(args).unwrap();
 	let keysend_preimage = extract_payment_preimage(&claimable_ev);
 	claim_payment_along_route(ClaimAlongRouteArgs::new(&nodes[0], route, keysend_preimage));
@@ -1858,6 +1868,13 @@ fn expired_static_invoice_payment_path() {
 		blinded_path
 			.advance_path_by_one(&nodes[1].keys_manager, &nodes[1].node, &secp_ctx)
 			.unwrap();
+
+		for _ in 0..DEFAULT_PAYMENT_DUMMY_HOPS {
+			blinded_path
+				.advance_path_by_one(&nodes[2].keys_manager, &nodes[2].node, &secp_ctx)
+				.unwrap();
+		}
+
 		match blinded_path.decrypt_intro_payload(&nodes[2].keys_manager).unwrap().0 {
 			BlindedPaymentTlvs::Receive(tlvs) => tlvs.payment_constraints.max_cltv_expiry,
 			_ => panic!(),
@@ -1920,7 +1937,8 @@ fn expired_static_invoice_payment_path() {
 	let route: &[&[&Node]] = &[&[&nodes[1], &nodes[2]]];
 	let args = PassAlongPathArgs::new(&nodes[0], route[0], amt_msat, payment_hash, ev)
 		.without_claimable_event()
-		.expect_failure(HTLCHandlingFailureType::Receive { payment_hash });
+		.expect_failure(HTLCHandlingFailureType::Receive { payment_hash })
+		.with_dummy_tlvs(&[DummyTlvs::default(); DEFAULT_PAYMENT_DUMMY_HOPS]);
 	do_pass_along_path(args);
 	fail_blinded_htlc_backwards(payment_hash, 1, &[&nodes[0], &nodes[1], &nodes[2]], false);
 	nodes[2].logger.assert_log_contains(
@@ -2363,7 +2381,8 @@ fn refresh_static_invoices_for_used_offers() {
 	check_added_monitors!(sender, 1);
 
 	let route: &[&[&Node]] = &[&[server, recipient]];
-	let args = PassAlongPathArgs::new(sender, route[0], amt_msat, payment_hash, ev);
+	let args = PassAlongPathArgs::new(sender, route[0], amt_msat, payment_hash, ev)
+		.with_dummy_tlvs(&[DummyTlvs::default(); DEFAULT_PAYMENT_DUMMY_HOPS]);
 	let claimable_ev = do_pass_along_path(args).unwrap();
 	let keysend_preimage = extract_payment_preimage(&claimable_ev);
 	let res = claim_payment_along_route(ClaimAlongRouteArgs::new(sender, route, keysend_preimage));
@@ -2697,7 +2716,8 @@ fn invoice_server_is_not_channel_peer() {
 	check_added_monitors!(sender, 1);
 
 	let route: &[&[&Node]] = &[&[forwarding_node, recipient]];
-	let args = PassAlongPathArgs::new(sender, route[0], amt_msat, payment_hash, ev);
+	let args = PassAlongPathArgs::new(sender, route[0], amt_msat, payment_hash, ev)
+		.with_dummy_tlvs(&[DummyTlvs::default(); DEFAULT_PAYMENT_DUMMY_HOPS]);
 	let claimable_ev = do_pass_along_path(args).unwrap();
 	let keysend_preimage = extract_payment_preimage(&claimable_ev);
 	let res = claim_payment_along_route(ClaimAlongRouteArgs::new(sender, route, keysend_preimage));
@@ -2936,7 +2956,8 @@ fn async_payment_e2e() {
 	check_added_monitors!(sender_lsp, 1);
 
 	let path: &[&Node] = &[invoice_server, recipient];
-	let args = PassAlongPathArgs::new(sender_lsp, path, amt_msat, payment_hash, ev);
+	let args = PassAlongPathArgs::new(sender_lsp, path, amt_msat, payment_hash, ev)
+		.with_dummy_tlvs(&[DummyTlvs::default(); DEFAULT_PAYMENT_DUMMY_HOPS]);
 	let claimable_ev = do_pass_along_path(args).unwrap();
 
 	let route: &[&[&Node]] = &[&[sender_lsp, invoice_server, recipient]];
@@ -3173,7 +3194,8 @@ fn intercepted_hold_htlc() {
 	check_added_monitors!(lsp, 1);
 
 	let path: &[&Node] = &[recipient];
-	let args = PassAlongPathArgs::new(lsp, path, amt_msat, payment_hash, ev);
+	let args = PassAlongPathArgs::new(lsp, path, amt_msat, payment_hash, ev)
+		.with_dummy_tlvs(&[DummyTlvs::default(); DEFAULT_PAYMENT_DUMMY_HOPS]);
 	let claimable_ev = do_pass_along_path(args).unwrap();
 
 	let route: &[&[&Node]] = &[&[lsp, recipient]];
@@ -3276,7 +3298,8 @@ fn async_payment_mpp() {
 	assert_eq!(events.len(), 1);
 	let ev = remove_first_msg_event_to_node(&recipient.node.get_our_node_id(), &mut events);
 	let args = PassAlongPathArgs::new(lsp_a, expected_path, amt_msat, payment_hash, ev)
-		.without_claimable_event();
+		.without_claimable_event()
+		.with_dummy_tlvs(&[DummyTlvs::default(); DEFAULT_PAYMENT_DUMMY_HOPS]);
 	do_pass_along_path(args);
 
 	lsp_b.node.process_pending_htlc_forwards();
@@ -3284,7 +3307,8 @@ fn async_payment_mpp() {
 	let mut events = lsp_b.node.get_and_clear_pending_msg_events();
 	assert_eq!(events.len(), 1);
 	let ev = remove_first_msg_event_to_node(&recipient.node.get_our_node_id(), &mut events);
-	let args = PassAlongPathArgs::new(lsp_b, expected_path, amt_msat, payment_hash, ev);
+	let args = PassAlongPathArgs::new(lsp_b, expected_path, amt_msat, payment_hash, ev)
+		.with_dummy_tlvs(&[DummyTlvs::default(); DEFAULT_PAYMENT_DUMMY_HOPS]);
 	let claimable_ev = do_pass_along_path(args).unwrap();
 
 	let keysend_preimage = match claimable_ev {
@@ -3420,7 +3444,8 @@ fn release_htlc_races_htlc_onion_decode() {
 	check_added_monitors!(sender_lsp, 1);
 
 	let path: &[&Node] = &[invoice_server, recipient];
-	let args = PassAlongPathArgs::new(sender_lsp, path, amt_msat, payment_hash, ev);
+	let args = PassAlongPathArgs::new(sender_lsp, path, amt_msat, payment_hash, ev)
+		.with_dummy_tlvs(&[DummyTlvs::default(); DEFAULT_PAYMENT_DUMMY_HOPS]);
 	let claimable_ev = do_pass_along_path(args).unwrap();
 
 	let route: &[&[&Node]] = &[&[sender_lsp, invoice_server, recipient]];

--- a/lightning/src/ln/blinded_payment_tests.rs
+++ b/lightning/src/ln/blinded_payment_tests.rs
@@ -1526,6 +1526,7 @@ fn update_add_msg(
 		skimmed_fee_msat: None,
 		blinding_point,
 		hold_htlc: None,
+		accountable: None,
 	}
 }
 

--- a/lightning/src/ln/channel.rs
+++ b/lightning/src/ln/channel.rs
@@ -9747,6 +9747,7 @@ where
 					skimmed_fee_msat: htlc.skimmed_fee_msat,
 					blinding_point: htlc.blinding_point,
 					hold_htlc: htlc.hold_htlc,
+					accountable: None,
 				});
 			}
 		}

--- a/lightning/src/ln/channel.rs
+++ b/lightning/src/ln/channel.rs
@@ -6501,8 +6501,7 @@ fn get_v2_channel_reserve_satoshis(channel_value_satoshis: u64, dust_limit_satos
 fn check_splice_contribution_sufficient(
 	contribution: &SpliceContribution, is_initiator: bool, funding_feerate: FeeRate,
 ) -> Result<SignedAmount, String> {
-	let contribution_amount = contribution.value();
-	if contribution_amount < SignedAmount::ZERO {
+	if contribution.inputs().is_empty() {
 		let estimated_fee = Amount::from_sat(estimate_v2_funding_transaction_fee(
 			contribution.inputs(),
 			contribution.outputs(),
@@ -6511,20 +6510,25 @@ fn check_splice_contribution_sufficient(
 			funding_feerate.to_sat_per_kwu() as u32,
 		));
 
+		let contribution_amount = contribution.net_value();
 		contribution_amount
 			.checked_sub(
 				estimated_fee.to_signed().expect("fees should never exceed Amount::MAX_MONEY"),
 			)
-			.ok_or(format!("Our {contribution_amount} contribution plus the fee estimate exceeds the total bitcoin supply"))
+			.ok_or(format!(
+				"{estimated_fee} splice-out amount plus {} fee estimate exceeds the total bitcoin supply",
+				contribution_amount.unsigned_abs(),
+			))
 	} else {
 		check_v2_funding_inputs_sufficient(
-			contribution_amount.to_sat(),
+			contribution.value_added(),
 			contribution.inputs(),
+			contribution.outputs(),
 			is_initiator,
 			true,
 			funding_feerate.to_sat_per_kwu() as u32,
 		)
-		.map(|_| contribution_amount)
+		.map(|_| contribution.net_value())
 	}
 }
 
@@ -6583,16 +6587,16 @@ fn estimate_v2_funding_transaction_fee(
 /// Returns estimated (partial) fees as additional information
 #[rustfmt::skip]
 fn check_v2_funding_inputs_sufficient(
-	contribution_amount: i64, funding_inputs: &[FundingTxInput], is_initiator: bool,
-	is_splice: bool, funding_feerate_sat_per_1000_weight: u32,
-) -> Result<u64, String> {
-	let estimated_fee = estimate_v2_funding_transaction_fee(
-		funding_inputs, &[], is_initiator, is_splice, funding_feerate_sat_per_1000_weight,
-	);
+	contributed_input_value: Amount, funding_inputs: &[FundingTxInput], outputs: &[TxOut],
+	is_initiator: bool, is_splice: bool, funding_feerate_sat_per_1000_weight: u32,
+) -> Result<Amount, String> {
+	let estimated_fee = Amount::from_sat(estimate_v2_funding_transaction_fee(
+		funding_inputs, outputs, is_initiator, is_splice, funding_feerate_sat_per_1000_weight,
+	));
 
-	let mut total_input_sats = 0u64;
+	let mut total_input_value = Amount::ZERO;
 	for FundingTxInput { utxo, .. } in funding_inputs.iter() {
-		total_input_sats = total_input_sats.checked_add(utxo.output.value.to_sat())
+		total_input_value = total_input_value.checked_add(utxo.output.value)
 			.ok_or("Sum of input values is greater than the total bitcoin supply")?;
 	}
 
@@ -6607,13 +6611,11 @@ fn check_v2_funding_inputs_sufficient(
 	// TODO(splicing): refine check including the fact wether a change will be added or not.
 	// Can be done once dual funding preparation is included.
 
-	let minimal_input_amount_needed = contribution_amount.checked_add(estimated_fee as i64)
-		.ok_or(format!("Our {contribution_amount} contribution plus the fee estimate exceeds the total bitcoin supply"))?;
-	if i64::try_from(total_input_sats).map_err(|_| "Sum of input values is greater than the total bitcoin supply")?
-		< minimal_input_amount_needed
-	{
+	let minimal_input_amount_needed = contributed_input_value.checked_add(estimated_fee)
+		.ok_or(format!("{contributed_input_value} contribution plus {estimated_fee} fee estimate exceeds the total bitcoin supply"))?;
+	if total_input_value < minimal_input_amount_needed {
 		Err(format!(
-			"Total input amount {total_input_sats} is lower than needed for contribution {contribution_amount}, considering fees of {estimated_fee}. Need more inputs.",
+			"Total input amount {total_input_value} is lower than needed for splice-in contribution {contributed_input_value}, considering fees of {estimated_fee}. Need more inputs.",
 		))
 	} else {
 		Ok(estimated_fee)
@@ -6679,7 +6681,7 @@ impl FundingNegotiationContext {
 		};
 
 		// Optionally add change output
-		let change_value_opt = if self.our_funding_contribution > SignedAmount::ZERO {
+		let change_value_opt = if !self.our_funding_inputs.is_empty() {
 			match calculate_change_output_value(
 				&self,
 				self.shared_funding_input.is_some(),
@@ -12070,7 +12072,7 @@ where
 			});
 		}
 
-		let our_funding_contribution = contribution.value();
+		let our_funding_contribution = contribution.net_value();
 		if our_funding_contribution == SignedAmount::ZERO {
 			return Err(APIError::APIMisuseError {
 				err: format!(
@@ -18525,6 +18527,13 @@ mod tests {
 		FundingTxInput::new_p2wpkh(prevtx, 0).unwrap()
 	}
 
+	fn funding_output_sats(output_value_sats: u64) -> TxOut {
+		TxOut {
+			value: Amount::from_sat(output_value_sats),
+			script_pubkey: ScriptBuf::new_p2wpkh(&WPubkeyHash::all_zeros()),
+		}
+	}
+
 	#[test]
 	#[rustfmt::skip]
 	fn test_check_v2_funding_inputs_sufficient() {
@@ -18535,16 +18544,83 @@ mod tests {
 			let expected_fee = if cfg!(feature = "grind_signatures") { 2278 } else { 2284 };
 			assert_eq!(
 				check_v2_funding_inputs_sufficient(
-					220_000,
+					Amount::from_sat(220_000),
 					&[
 						funding_input_sats(200_000),
 						funding_input_sats(100_000),
+					],
+					&[],
+					true,
+					true,
+					2000,
+				).unwrap(),
+				Amount::from_sat(expected_fee),
+			);
+		}
+
+		// Net splice-in
+		{
+			let expected_fee = if cfg!(feature = "grind_signatures") { 2526 } else { 2532 };
+			assert_eq!(
+				check_v2_funding_inputs_sufficient(
+					Amount::from_sat(220_000),
+					&[
+						funding_input_sats(200_000),
+						funding_input_sats(100_000),
+					],
+					&[
+						funding_output_sats(200_000),
 					],
 					true,
 					true,
 					2000,
 				).unwrap(),
-				expected_fee,
+				Amount::from_sat(expected_fee),
+			);
+		}
+
+		// Net splice-out
+		{
+			let expected_fee = if cfg!(feature = "grind_signatures") { 2526 } else { 2532 };
+			assert_eq!(
+				check_v2_funding_inputs_sufficient(
+					Amount::from_sat(220_000),
+					&[
+						funding_input_sats(200_000),
+						funding_input_sats(100_000),
+					],
+					&[
+						funding_output_sats(400_000),
+					],
+					true,
+					true,
+					2000,
+				).unwrap(),
+				Amount::from_sat(expected_fee),
+			);
+		}
+
+		// Net splice-out, inputs insufficient to cover fees
+		{
+			let expected_fee = if cfg!(feature = "grind_signatures") { 113670 } else { 113940 };
+			assert_eq!(
+				check_v2_funding_inputs_sufficient(
+					Amount::from_sat(220_000),
+					&[
+						funding_input_sats(200_000),
+						funding_input_sats(100_000),
+					],
+					&[
+						funding_output_sats(400_000),
+					],
+					true,
+					true,
+					90000,
+				),
+				Err(format!(
+					"Total input amount 0.00300000 BTC is lower than needed for splice-in contribution 0.00220000 BTC, considering fees of {}. Need more inputs.",
+					Amount::from_sat(expected_fee),
+				)),
 			);
 		}
 
@@ -18553,17 +18629,18 @@ mod tests {
 			let expected_fee = if cfg!(feature = "grind_signatures") { 1736 } else { 1740 };
 			assert_eq!(
 				check_v2_funding_inputs_sufficient(
-					220_000,
+					Amount::from_sat(220_000),
 					&[
 						funding_input_sats(100_000),
 					],
+					&[],
 					true,
 					true,
 					2000,
 				),
 				Err(format!(
-					"Total input amount 100000 is lower than needed for contribution 220000, considering fees of {}. Need more inputs.",
-					expected_fee,
+					"Total input amount 0.00100000 BTC is lower than needed for splice-in contribution 0.00220000 BTC, considering fees of {}. Need more inputs.",
+					Amount::from_sat(expected_fee),
 				)),
 			);
 		}
@@ -18573,16 +18650,17 @@ mod tests {
 			let expected_fee = if cfg!(feature = "grind_signatures") { 2278 } else { 2284 };
 			assert_eq!(
 				check_v2_funding_inputs_sufficient(
-					(300_000 - expected_fee - 20) as i64,
+					Amount::from_sat(300_000 - expected_fee - 20),
 					&[
 						funding_input_sats(200_000),
 						funding_input_sats(100_000),
 					],
+					&[],
 					true,
 					true,
 					2000,
 				).unwrap(),
-				expected_fee,
+				Amount::from_sat(expected_fee),
 			);
 		}
 
@@ -18591,18 +18669,19 @@ mod tests {
 			let expected_fee = if cfg!(feature = "grind_signatures") { 2506 } else { 2513 };
 			assert_eq!(
 				check_v2_funding_inputs_sufficient(
-					298032,
+					Amount::from_sat(298032),
 					&[
 						funding_input_sats(200_000),
 						funding_input_sats(100_000),
 					],
+					&[],
 					true,
 					true,
 					2200,
 				),
 				Err(format!(
-					"Total input amount 300000 is lower than needed for contribution 298032, considering fees of {}. Need more inputs.",
-					expected_fee
+					"Total input amount 0.00300000 BTC is lower than needed for splice-in contribution 0.00298032 BTC, considering fees of {}. Need more inputs.",
+					Amount::from_sat(expected_fee),
 				)),
 			);
 		}
@@ -18612,16 +18691,17 @@ mod tests {
 			let expected_fee = if cfg!(feature = "grind_signatures") { 1084 } else { 1088 };
 			assert_eq!(
 				check_v2_funding_inputs_sufficient(
-					(300_000 - expected_fee - 20) as i64,
+					Amount::from_sat(300_000 - expected_fee - 20),
 					&[
 						funding_input_sats(200_000),
 						funding_input_sats(100_000),
 					],
+					&[],
 					false,
 					false,
 					2000,
 				).unwrap(),
-				expected_fee,
+				Amount::from_sat(expected_fee),
 			);
 		}
 	}

--- a/lightning/src/ln/channel.rs
+++ b/lightning/src/ln/channel.rs
@@ -6707,12 +6707,12 @@ impl FundingNegotiationContext {
 					},
 				}
 			};
-			let mut change_output =
-				TxOut { value: Amount::from_sat(change_value), script_pubkey: change_script };
+			let mut change_output = TxOut { value: change_value, script_pubkey: change_script };
 			let change_output_weight = get_output_weight(&change_output.script_pubkey).to_wu();
 			let change_output_fee =
 				fee_for_weight(self.funding_feerate_sat_per_1000_weight, change_output_weight);
-			let change_value_decreased_with_fee = change_value.saturating_sub(change_output_fee);
+			let change_value_decreased_with_fee =
+				change_value.to_sat().saturating_sub(change_output_fee);
 			// Check dust limit again
 			if change_value_decreased_with_fee > context.holder_dust_limit_satoshis {
 				change_output.value = Amount::from_sat(change_value_decreased_with_fee);

--- a/lightning/src/ln/channel.rs
+++ b/lightning/src/ln/channel.rs
@@ -8981,7 +8981,6 @@ where
 							update_fail_htlcs.len() + update_fail_malformed_htlcs.len(),
 							&self.context.channel_id);
 					} else {
-						debug_assert!(htlcs_to_fail.is_empty());
 						let reason = if self.context.channel_state.is_local_stfu_sent() {
 							"exits quiescence"
 						} else if self.context.channel_state.is_monitor_update_in_progress() {

--- a/lightning/src/ln/channel.rs
+++ b/lightning/src/ln/channel.rs
@@ -1914,13 +1914,8 @@ where
 				.handle_tx_complete(msg)
 				.map_err(|reason| self.fail_interactive_tx_negotiation(reason, logger))?,
 			None => {
-				return Err((
-					ChannelError::WarnAndDisconnect(
-						"Received unexpected interactive transaction negotiation message"
-							.to_owned(),
-					),
-					None,
-				))
+				let err = "Received unexpected interactive transaction negotiation message";
+				return Err((ChannelError::WarnAndDisconnect(err.to_owned()), None));
 			},
 		};
 
@@ -13806,28 +13801,20 @@ where
 		L::Target: Logger,
 	{
 		if !self.funding.is_outbound() {
-			return Err((
-				self,
-				ChannelError::close("Received funding_signed for an inbound channel?".to_owned()),
-			));
+			let err = "Received funding_signed for an inbound channel?";
+			return Err((self, ChannelError::close(err.to_owned())));
 		}
 		if !matches!(self.context.channel_state, ChannelState::FundingNegotiated(_)) {
-			return Err((
-				self,
-				ChannelError::close("Received funding_signed in strange state!".to_owned()),
-			));
+			let err = "Received funding_signed in strange state!";
+			return Err((self, ChannelError::close(err.to_owned())));
 		}
-		let mut holder_commitment_point =
-			match self.unfunded_context.holder_commitment_point {
-				Some(point) => point,
-				None => return Err((
-					self,
-					ChannelError::close(
-						"Received funding_signed before our first commitment point was available"
-							.to_owned(),
-					),
-				)),
-			};
+		let mut holder_commitment_point = match self.unfunded_context.holder_commitment_point {
+			Some(point) => point,
+			None => {
+				let err = "Received funding_signed before our first commitment point was available";
+				return Err((self, ChannelError::close(err.to_owned())));
+			},
+		};
 		self.context.assert_no_commitment_advancement(
 			holder_commitment_point.next_transaction_number(),
 			"funding_signed",
@@ -14117,10 +14104,8 @@ where
 		L::Target: Logger,
 	{
 		if self.funding.is_outbound() {
-			return Err((
-				self,
-				ChannelError::close("Received funding_created for an outbound channel?".to_owned()),
-			));
+			let err = "Received funding_created for an outbound channel?";
+			return Err((self, ChannelError::close(err.to_owned())));
 		}
 		if !matches!(
 			self.context.channel_state, ChannelState::NegotiatingFunding(flags)
@@ -14129,24 +14114,17 @@ where
 			// BOLT 2 says that if we disconnect before we send funding_signed we SHOULD NOT
 			// remember the channel, so it's safe to just send an error_message here and drop the
 			// channel.
-			return Err((
-				self,
-				ChannelError::close(
-					"Received funding_created after we got the channel!".to_owned(),
-				),
-			));
+			let err = "Received funding_created after we got the channel!";
+			return Err((self, ChannelError::close(err.to_owned())));
 		}
-		let mut holder_commitment_point =
-			match self.unfunded_context.holder_commitment_point {
-				Some(point) => point,
-				None => return Err((
-					self,
-					ChannelError::close(
-						"Received funding_created before our first commitment point was available"
-							.to_owned(),
-					),
-				)),
-			};
+		let mut holder_commitment_point = match self.unfunded_context.holder_commitment_point {
+			Some(point) => point,
+			None => {
+				let err =
+					"Received funding_created before our first commitment point was available";
+				return Err((self, ChannelError::close(err.to_owned())));
+			},
+		};
 		self.context.assert_no_commitment_advancement(
 			holder_commitment_point.next_transaction_number(),
 			"funding_created",

--- a/lightning/src/ln/channel.rs
+++ b/lightning/src/ln/channel.rs
@@ -14713,7 +14713,7 @@ where
 			}
 		}
 		let mut removed_htlc_attribution_data: Vec<&Option<AttributionData>> = Vec::new();
-		let mut inbound_committed_update_adds: Vec<Option<msgs::UpdateAddHTLC>> = Vec::new();
+		let mut inbound_committed_update_adds: Vec<&Option<msgs::UpdateAddHTLC>> = Vec::new();
 		(self.context.pending_inbound_htlcs.len() as u64 - dropped_inbound_htlcs).write(writer)?;
 		for htlc in self.context.pending_inbound_htlcs.iter() {
 			if let &InboundHTLCState::RemoteAnnounced(_) = &htlc.state {
@@ -14735,7 +14735,7 @@ where
 				},
 				&InboundHTLCState::Committed { ref update_add_htlc_opt } => {
 					3u8.write(writer)?;
-					inbound_committed_update_adds.push(update_add_htlc_opt.clone());
+					inbound_committed_update_adds.push(update_add_htlc_opt);
 				},
 				&InboundHTLCState::LocalRemoved(ref removal_reason) => {
 					4u8.write(writer)?;

--- a/lightning/src/ln/channel.rs
+++ b/lightning/src/ln/channel.rs
@@ -9392,10 +9392,9 @@ where
 	/// [`ChannelMonitorUpdateStatus::InProgress`]: crate::chain::ChannelMonitorUpdateStatus::InProgress
 	fn monitor_updating_paused<L: Deref>(
 		&mut self, resend_raa: bool, resend_commitment: bool, resend_channel_ready: bool,
-		mut pending_forwards: Vec<(PendingHTLCInfo, u64)>,
-		mut pending_fails: Vec<(HTLCSource, PaymentHash, HTLCFailReason)>,
-		mut pending_finalized_claimed_htlcs: Vec<(HTLCSource, Option<AttributionData>)>,
-		logger: &L,
+		pending_forwards: Vec<(PendingHTLCInfo, u64)>,
+		pending_fails: Vec<(HTLCSource, PaymentHash, HTLCFailReason)>,
+		pending_finalized_claimed_htlcs: Vec<(HTLCSource, Option<AttributionData>)>, logger: &L,
 	) where
 		L::Target: Logger,
 	{
@@ -9404,11 +9403,9 @@ where
 		self.context.monitor_pending_revoke_and_ack |= resend_raa;
 		self.context.monitor_pending_commitment_signed |= resend_commitment;
 		self.context.monitor_pending_channel_ready |= resend_channel_ready;
-		self.context.monitor_pending_forwards.append(&mut pending_forwards);
-		self.context.monitor_pending_failures.append(&mut pending_fails);
-		self.context
-			.monitor_pending_finalized_fulfills
-			.append(&mut pending_finalized_claimed_htlcs);
+		self.context.monitor_pending_forwards.extend(pending_forwards);
+		self.context.monitor_pending_failures.extend(pending_fails);
+		self.context.monitor_pending_finalized_fulfills.extend(pending_finalized_claimed_htlcs);
 		self.context.channel_state.set_monitor_update_in_progress();
 	}
 

--- a/lightning/src/ln/channel.rs
+++ b/lightning/src/ln/channel.rs
@@ -16330,6 +16330,7 @@ mod tests {
 				first_hop_htlc_msat: 548,
 				payment_id: PaymentId([42; 32]),
 				bolt12_invoice: None,
+				payment_nonce: None,
 			},
 			skimmed_fee_msat: None,
 			blinding_point: None,
@@ -16779,6 +16780,7 @@ mod tests {
 			first_hop_htlc_msat: 0,
 			payment_id: PaymentId([42; 32]),
 			bolt12_invoice: None,
+			payment_nonce: None,
 		};
 		let dummy_outbound_output = OutboundHTLCOutput {
 			htlc_id: 0,

--- a/lightning/src/ln/channelmanager.rs
+++ b/lightning/src/ln/channelmanager.rs
@@ -4974,6 +4974,11 @@ where
 	) -> Result<(), LocalHTLCFailureReason> {
 		let outgoing_scid = match next_packet_details.outgoing_connector {
 			HopConnector::ShortChannelId(scid) => scid,
+			HopConnector::Dummy => {
+				// Dummy hops are only used for path padding and must not reach HTLC processing.
+				debug_assert!(false, "Dummy hop reached HTLC handling.");
+				return Err(LocalHTLCFailureReason::InvalidOnionPayload);
+			}
 			HopConnector::Trampoline(_) => {
 				return Err(LocalHTLCFailureReason::InvalidTrampolineForward);
 			}
@@ -6878,6 +6883,7 @@ where
 	fn process_pending_update_add_htlcs(&self) -> bool {
 		let mut should_persist = false;
 		let mut decode_update_add_htlcs = new_hash_map();
+		let mut dummy_update_add_htlcs = new_hash_map();
 		mem::swap(&mut decode_update_add_htlcs, &mut self.decode_update_add_htlcs.lock().unwrap());
 
 		let get_htlc_failure_type = |outgoing_scid_opt: Option<u64>, payment_hash: PaymentHash| {
@@ -6941,7 +6947,36 @@ where
 						&*self.logger,
 						&self.secp_ctx,
 					) {
-						Ok(decoded_onion) => decoded_onion,
+						Ok(decoded_onion) => match decoded_onion {
+							(
+								onion_utils::Hop::Dummy {
+									dummy_hop_data,
+									next_hop_hmac,
+									new_packet_bytes,
+									..
+								},
+								Some(next_packet_details),
+							) => {
+								let new_update_add_htlc =
+									onion_utils::peel_dummy_hop_update_add_htlc(
+										update_add_htlc,
+										dummy_hop_data,
+										next_hop_hmac,
+										new_packet_bytes,
+										next_packet_details,
+										&*self.node_signer,
+										&self.secp_ctx,
+									);
+
+								dummy_update_add_htlcs
+									.entry(incoming_scid_alias)
+									.or_insert_with(Vec::new)
+									.push(new_update_add_htlc);
+
+								continue;
+							},
+							_ => decoded_onion,
+						},
 
 						Err((htlc_fail, reason)) => {
 							let failure_type = HTLCHandlingFailureType::InvalidOnion;
@@ -6954,6 +6989,13 @@ where
 				let outgoing_scid_opt =
 					next_packet_details_opt.as_ref().and_then(|d| match d.outgoing_connector {
 						HopConnector::ShortChannelId(scid) => Some(scid),
+						HopConnector::Dummy => {
+							debug_assert!(
+								false,
+								"Dummy hops must never be processed at this stage."
+							);
+							None
+						},
 						HopConnector::Trampoline(_) => None,
 					});
 				let shared_secret = next_hop.shared_secret().secret_bytes();
@@ -7097,6 +7139,19 @@ where
 				));
 			}
 		}
+
+		// Merge peeled dummy HTLCs into the existing decode queue so they can be
+		// processed in the next iteration. We avoid replacing the whole queue
+		// (e.g. via mem::swap) because other threads may have enqueued new HTLCs
+		// meanwhile; merging preserves everything safely.
+		if !dummy_update_add_htlcs.is_empty() {
+			let mut decode_update_add_htlc_source = self.decode_update_add_htlcs.lock().unwrap();
+
+			for (incoming_scid_alias, htlcs) in dummy_update_add_htlcs.into_iter() {
+				decode_update_add_htlc_source.entry(incoming_scid_alias).or_default().extend(htlcs);
+			}
+		}
+
 		should_persist
 	}
 

--- a/lightning/src/ln/channelmanager.rs
+++ b/lightning/src/ln/channelmanager.rs
@@ -18005,156 +18005,165 @@ where
 					is_channel_closed = !peer_state.channel_by_id.contains_key(channel_id);
 				}
 
-				if is_channel_closed {
-					for (htlc_source, (htlc, preimage_opt)) in
-						monitor.get_all_current_outbound_htlcs()
-					{
-						let logger = WithChannelMonitor::from(
-							&args.logger,
-							monitor,
-							Some(htlc.payment_hash),
-						);
-						let htlc_id = SentHTLCId::from_source(&htlc_source);
-						match htlc_source {
-							HTLCSource::PreviousHopData(prev_hop_data) => {
-								let pending_forward_matches_htlc = |info: &PendingAddHTLCInfo| {
-									info.prev_funding_outpoint == prev_hop_data.outpoint
-										&& info.prev_htlc_id == prev_hop_data.htlc_id
-								};
-								// The ChannelMonitor is now responsible for this HTLC's
-								// failure/success and will let us know what its outcome is. If we
-								// still have an entry for this HTLC in `forward_htlcs`,
-								// `pending_intercepted_htlcs`, or `decode_update_add_htlcs`, we were apparently not
-								// persisted after the monitor was when forwarding the payment.
-								dedup_decode_update_add_htlcs(
-									&mut decode_update_add_htlcs,
-									&prev_hop_data,
-									"HTLC was forwarded to the closed channel",
-									&args.logger,
-								);
-								dedup_decode_update_add_htlcs(
-									&mut decode_update_add_htlcs_legacy,
-									&prev_hop_data,
-									"HTLC was forwarded to the closed channel",
-									&args.logger,
-								);
-								forward_htlcs_legacy.retain(|_, forwards| {
-									forwards.retain(|forward| {
-										if let HTLCForwardInfo::AddHTLC(htlc_info) = forward {
-											if pending_forward_matches_htlc(&htlc_info) {
-												log_info!(logger, "Removing pending to-forward HTLC with hash {} as it was forwarded to the closed channel {}",
-													&htlc.payment_hash, &monitor.channel_id());
-												false
-											} else { true }
+				for (htlc_source, (htlc, preimage_opt)) in monitor.get_all_current_outbound_htlcs()
+				{
+					let logger =
+						WithChannelMonitor::from(&args.logger, monitor, Some(htlc.payment_hash));
+					let htlc_id = SentHTLCId::from_source(&htlc_source);
+					match htlc_source {
+						HTLCSource::PreviousHopData(prev_hop_data) => {
+							let pending_forward_matches_htlc = |info: &PendingAddHTLCInfo| {
+								info.prev_funding_outpoint == prev_hop_data.outpoint
+									&& info.prev_htlc_id == prev_hop_data.htlc_id
+							};
+							if !is_channel_closed {
+								continue;
+							}
+							// The ChannelMonitor is now responsible for this HTLC's
+							// failure/success and will let us know what its outcome is. If we
+							// still have an entry for this HTLC in `forward_htlcs`,
+							// `pending_intercepted_htlcs`, or `decode_update_add_htlcs`, we were apparently not
+							// persisted after the monitor was when forwarding the payment.
+							dedup_decode_update_add_htlcs(
+								&mut decode_update_add_htlcs,
+								&prev_hop_data,
+								"HTLC was forwarded to the closed channel",
+								&args.logger,
+							);
+							dedup_decode_update_add_htlcs(
+								&mut decode_update_add_htlcs_legacy,
+								&prev_hop_data,
+								"HTLC was forwarded to the closed channel",
+								&args.logger,
+							);
+							forward_htlcs_legacy.retain(|_, forwards| {
+								forwards.retain(|forward| {
+									if let HTLCForwardInfo::AddHTLC(htlc_info) = forward {
+										if pending_forward_matches_htlc(&htlc_info) {
+											log_info!(logger, "Removing pending to-forward HTLC with hash {} as it was forwarded to the closed channel {}",
+												&htlc.payment_hash, &monitor.channel_id());
+											false
 										} else { true }
-									});
-									!forwards.is_empty()
-								});
-								pending_intercepted_htlcs_legacy.retain(|intercepted_id, htlc_info| {
-									if pending_forward_matches_htlc(&htlc_info) {
-										log_info!(logger, "Removing pending intercepted HTLC with hash {} as it was forwarded to the closed channel {}",
-											&htlc.payment_hash, &monitor.channel_id());
-										pending_events_read.retain(|(event, _)| {
-											if let Event::HTLCIntercepted { intercept_id: ev_id, .. } = event {
-												intercepted_id != ev_id
-											} else { true }
-										});
-										false
 									} else { true }
 								});
-							},
-							HTLCSource::OutboundRoute {
-								payment_id,
-								session_priv,
-								path,
-								bolt12_invoice,
-								..
-							} => {
-								if let Some(preimage) = preimage_opt {
-									let pending_events = Mutex::new(pending_events_read);
-									let update = PaymentCompleteUpdate {
-										counterparty_node_id: monitor.get_counterparty_node_id(),
-										channel_funding_outpoint: monitor.get_funding_txo(),
-										channel_id: monitor.channel_id(),
-										htlc_id,
-									};
-									let mut compl_action = Some(
-										EventCompletionAction::ReleasePaymentCompleteChannelMonitorUpdate(update)
-									);
-									pending_outbounds.claim_htlc(
-										payment_id,
-										preimage,
-										bolt12_invoice,
-										session_priv,
-										path,
-										true,
-										&mut compl_action,
-										&pending_events,
-									);
-									// If the completion action was not consumed, then there was no
-									// payment to claim, and we need to tell the `ChannelMonitor`
-									// we don't need to hear about the HTLC again, at least as long
-									// as the PaymentSent event isn't still sitting around in our
-									// event queue.
-									let have_action = if compl_action.is_some() {
-										let pending_events = pending_events.lock().unwrap();
-										pending_events.iter().any(|(_, act)| *act == compl_action)
-									} else {
-										false
-									};
-									if !have_action && compl_action.is_some() {
-										let mut peer_state = per_peer_state
-											.get(&counterparty_node_id)
-											.map(|state| state.lock().unwrap())
-											.expect("Channels originating a preimage must have peer state");
-										let update_id = peer_state
-											.closed_channel_monitor_update_ids
-											.get_mut(channel_id)
-											.expect("Channels originating a preimage must have a monitor");
-										// Note that for channels closed pre-0.1, the latest
-										// update_id is `u64::MAX`.
-										*update_id = update_id.saturating_add(1);
+								!forwards.is_empty()
+							});
+							pending_intercepted_htlcs_legacy.retain(|intercepted_id, htlc_info| {
+								if pending_forward_matches_htlc(&htlc_info) {
+									log_info!(logger, "Removing pending intercepted HTLC with hash {} as it was forwarded to the closed channel {}",
+										&htlc.payment_hash, &monitor.channel_id());
+									pending_events_read.retain(|(event, _)| {
+										if let Event::HTLCIntercepted { intercept_id: ev_id, .. } = event {
+											intercepted_id != ev_id
+										} else { true }
+									});
+									false
+								} else { true }
+							});
+						},
+						HTLCSource::OutboundRoute {
+							payment_id,
+							session_priv,
+							path,
+							bolt12_invoice,
+							..
+						} => {
+							if !is_channel_closed {
+								continue;
+							}
+							if let Some(preimage) = preimage_opt {
+								let pending_events = Mutex::new(pending_events_read);
+								let update = PaymentCompleteUpdate {
+									counterparty_node_id: monitor.get_counterparty_node_id(),
+									channel_funding_outpoint: monitor.get_funding_txo(),
+									channel_id: monitor.channel_id(),
+									htlc_id,
+								};
+								let mut compl_action = Some(
+									EventCompletionAction::ReleasePaymentCompleteChannelMonitorUpdate(update)
+								);
+								pending_outbounds.claim_htlc(
+									payment_id,
+									preimage,
+									bolt12_invoice,
+									session_priv,
+									path,
+									true,
+									&mut compl_action,
+									&pending_events,
+								);
+								// If the completion action was not consumed, then there was no
+								// payment to claim, and we need to tell the `ChannelMonitor`
+								// we don't need to hear about the HTLC again, at least as long
+								// as the PaymentSent event isn't still sitting around in our
+								// event queue.
+								let have_action = if compl_action.is_some() {
+									let pending_events = pending_events.lock().unwrap();
+									pending_events.iter().any(|(_, act)| *act == compl_action)
+								} else {
+									false
+								};
+								if !have_action && compl_action.is_some() {
+									let mut peer_state = per_peer_state
+										.get(&counterparty_node_id)
+										.map(|state| state.lock().unwrap())
+										.expect(
+											"Channels originating a preimage must have peer state",
+										);
+									let update_id = peer_state
+										.closed_channel_monitor_update_ids
+										.get_mut(channel_id)
+										.expect(
+											"Channels originating a preimage must have a monitor",
+										);
+									// Note that for channels closed pre-0.1, the latest
+									// update_id is `u64::MAX`.
+									*update_id = update_id.saturating_add(1);
 
-										pending_background_events.push(BackgroundEvent::MonitorUpdateRegeneratedOnStartup {
-											counterparty_node_id: monitor.get_counterparty_node_id(),
+									pending_background_events.push(
+										BackgroundEvent::MonitorUpdateRegeneratedOnStartup {
+											counterparty_node_id: monitor
+												.get_counterparty_node_id(),
 											funding_txo: monitor.get_funding_txo(),
 											channel_id: monitor.channel_id(),
 											update: ChannelMonitorUpdate {
 												update_id: *update_id,
 												channel_id: Some(monitor.channel_id()),
-												updates: vec![ChannelMonitorUpdateStep::ReleasePaymentComplete {
-													htlc: htlc_id,
-												}],
+												updates: vec![
+													ChannelMonitorUpdateStep::ReleasePaymentComplete {
+														htlc: htlc_id,
+													},
+												],
 											},
-										});
-									}
-									pending_events_read = pending_events.into_inner().unwrap();
+										},
+									);
 								}
-							},
-						}
+								pending_events_read = pending_events.into_inner().unwrap();
+							}
+						},
 					}
-					for (htlc_source, payment_hash) in monitor.get_onchain_failed_outbound_htlcs() {
-						log_info!(
-							args.logger,
-							"Failing HTLC with payment hash {} as it was resolved on-chain.",
-							payment_hash
-						);
-						let completion_action = Some(PaymentCompleteUpdate {
-							counterparty_node_id: monitor.get_counterparty_node_id(),
-							channel_funding_outpoint: monitor.get_funding_txo(),
-							channel_id: monitor.channel_id(),
-							htlc_id: SentHTLCId::from_source(&htlc_source),
-						});
+				}
+				for (htlc_source, payment_hash) in monitor.get_onchain_failed_outbound_htlcs() {
+					log_info!(
+						args.logger,
+						"Failing HTLC with payment hash {} as it was resolved on-chain.",
+						payment_hash
+					);
+					let completion_action = Some(PaymentCompleteUpdate {
+						counterparty_node_id: monitor.get_counterparty_node_id(),
+						channel_funding_outpoint: monitor.get_funding_txo(),
+						channel_id: monitor.channel_id(),
+						htlc_id: SentHTLCId::from_source(&htlc_source),
+					});
 
-						failed_htlcs.push((
-							htlc_source,
-							payment_hash,
-							monitor.get_counterparty_node_id(),
-							monitor.channel_id(),
-							LocalHTLCFailureReason::OnChainTimeout,
-							completion_action,
-						));
-					}
+					failed_htlcs.push((
+						htlc_source,
+						payment_hash,
+						monitor.get_counterparty_node_id(),
+						monitor.channel_id(),
+						LocalHTLCFailureReason::OnChainTimeout,
+						completion_action,
+					));
 				}
 
 				// Whether the downstream channel was closed or not, try to re-apply any payment

--- a/lightning/src/ln/channelmanager.rs
+++ b/lightning/src/ln/channelmanager.rs
@@ -18016,6 +18016,16 @@ where
 								info.prev_funding_outpoint == prev_hop_data.outpoint
 									&& info.prev_htlc_id == prev_hop_data.htlc_id
 							};
+							// We always add all inbound committed HTLCs to `decode_update_add_htlcs` in the above
+							// loop, but we need to prune from those added HTLCs if they were already forwarded to
+							// the outbound edge. Otherwise, we'll double-forward.
+							dedup_decode_update_add_htlcs(
+								&mut decode_update_add_htlcs,
+								&prev_hop_data,
+								"HTLC already forwarded to the outbound edge",
+								&args.logger,
+							);
+
 							if !is_channel_closed {
 								continue;
 							}
@@ -18024,12 +18034,6 @@ where
 							// still have an entry for this HTLC in `forward_htlcs`,
 							// `pending_intercepted_htlcs`, or `decode_update_add_htlcs`, we were apparently not
 							// persisted after the monitor was when forwarding the payment.
-							dedup_decode_update_add_htlcs(
-								&mut decode_update_add_htlcs,
-								&prev_hop_data,
-								"HTLC was forwarded to the closed channel",
-								&args.logger,
-							);
 							dedup_decode_update_add_htlcs(
 								&mut decode_update_add_htlcs_legacy,
 								&prev_hop_data,

--- a/lightning/src/ln/channelmanager.rs
+++ b/lightning/src/ln/channelmanager.rs
@@ -5105,6 +5105,20 @@ where
 			onion_utils::Hop::Forward { .. } | onion_utils::Hop::BlindedForward { .. } => {
 				create_fwd_pending_htlc_info(msg, decoded_hop, shared_secret, next_packet_pubkey_opt)
 			},
+			onion_utils::Hop::Dummy { .. } => {
+				debug_assert!(
+					false,
+					"Reached unreachable dummy-hop HTLC. Dummy hops are peeled in \
+					`process_pending_update_add_htlcs`, and the resulting HTLC is \
+					re-enqueued for processing. Hitting this means the peel-and-requeue \
+					step was missed."
+				);
+				return Err(InboundHTLCErr {
+					msg: "Failed to decode update add htlc onion",
+					reason: LocalHTLCFailureReason::InvalidOnionPayload,
+					err_data: Vec::new(),
+				})
+			},
 			onion_utils::Hop::TrampolineForward { .. } | onion_utils::Hop::TrampolineBlindedForward { .. } => {
 				create_fwd_pending_htlc_info(msg, decoded_hop, shared_secret, next_packet_pubkey_opt)
 			},

--- a/lightning/src/ln/channelmanager.rs
+++ b/lightning/src/ln/channelmanager.rs
@@ -18074,9 +18074,10 @@ where
 							}
 							// The ChannelMonitor is now responsible for this HTLC's
 							// failure/success and will let us know what its outcome is. If we
-							// still have an entry for this HTLC in `forward_htlcs`,
-							// `pending_intercepted_htlcs`, or `decode_update_add_htlcs`, we were apparently not
-							// persisted after the monitor was when forwarding the payment.
+							// still have an entry for this HTLC in `forward_htlcs_legacy`,
+							// `pending_intercepted_htlcs_legacy`, or
+							// `decode_update_add_htlcs_legacy`, we were apparently not persisted
+							// after the monitor was when forwarding the payment.
 							dedup_decode_update_add_htlcs(
 								&mut decode_update_add_htlcs_legacy,
 								&prev_hop_data,

--- a/lightning/src/ln/channelmanager.rs
+++ b/lightning/src/ln/channelmanager.rs
@@ -4854,6 +4854,12 @@ where
 	/// the channel. This will spend the channel's funding transaction output, effectively replacing
 	/// it with a new one.
 	///
+	/// # Required Feature Flags
+	///
+	/// Initiating a splice requires that the channel counterparty supports splicing. Any
+	/// channel (no matter the type) can be spliced, as long as the counterparty is currently
+	/// connected.
+	///
 	/// # Arguments
 	///
 	/// Provide a `contribution` to determine if value is spliced in or out. The splice initiator is

--- a/lightning/src/ln/channelmanager.rs
+++ b/lightning/src/ln/channelmanager.rs
@@ -5479,6 +5479,7 @@ where
 							onion_packet,
 							None,
 							hold_htlc_at_next_hop,
+							false, // Not accountable by default for sender.
 							&self.fee_estimator,
 							&&logger,
 						);
@@ -7587,6 +7588,7 @@ where
 								outgoing_cltv_value,
 								routing,
 								skimmed_fee_msat,
+								incoming_accountable,
 								..
 							},
 						..
@@ -7687,6 +7689,7 @@ where
 						onion_packet.clone(),
 						*skimmed_fee_msat,
 						next_blinding_point,
+						*incoming_accountable,
 						&self.fee_estimator,
 						&&logger,
 					) {

--- a/lightning/src/ln/channelmanager.rs
+++ b/lightning/src/ln/channelmanager.rs
@@ -3223,6 +3223,14 @@ pub struct PhantomRouteHints {
 	pub real_node_pubkey: PublicKey,
 }
 
+/// The return type of [`ChannelManager::check_free_peer_holding_cells`]
+type FreeHoldingCellsResult = Vec<(
+	ChannelId,
+	PublicKey,
+	Option<PostMonitorUpdateChanResume>,
+	Vec<(HTLCSource, PaymentHash)>,
+)>;
+
 macro_rules! insert_short_channel_id {
 	($short_to_chan_info: ident, $channel: expr) => {{
 		if let Some(real_scid) = $channel.funding.get_short_channel_id() {
@@ -3430,6 +3438,7 @@ macro_rules! process_events_body {
 			}
 
 			if !post_event_actions.is_empty() {
+				let _read_guard = $self.total_consistency_lock.read().unwrap();
 				$self.handle_post_event_actions(post_event_actions);
 				// If we had some actions, go around again as we may have more events now
 				processed_all_events = false;
@@ -7115,10 +7124,6 @@ where
 		}
 		self.forward_htlcs(&mut phantom_receives);
 
-		// Freeing the holding cell here is relatively redundant - in practice we'll do it when we
-		// next get a `get_and_clear_pending_msg_events` call, but some tests rely on it, and it's
-		// nice to do the work now if we can rather than while we're trying to get messages in the
-		// network stack.
 		if self.check_free_holding_cells() {
 			should_persist = NotifyOption::DoPersist;
 		}
@@ -8316,10 +8321,21 @@ where
 
 			self.check_refresh_async_receive_offer_cache(true);
 
-			// Technically we don't need to do this here, but if we have holding cell entries in a
-			// channel that need freeing, it's better to do that here and block a background task
-			// than block the message queueing pipeline.
 			if self.check_free_holding_cells() {
+				// While we try to ensure we clear holding cells immediately, its possible we miss
+				// one somewhere. Thus, its useful to try regularly to ensure even if something
+				// gets stuck its only for a minute or so. Still, good to panic here in debug to
+				// ensure we discover the missing free.
+				// Note that in cases where we had a fee update in the loop above, we expect to
+				// need to free holding cells now, thus we only report an error if `should_persist`
+				// has not been updated to `DoPersist`.
+				if should_persist != NotifyOption::DoPersist {
+					debug_assert!(false, "Holding cells are cleared immediately");
+					log_error!(
+						self.logger,
+						"Holding cells were freed in last-ditch cleanup. Please report this (performance) bug."
+					);
+				}
 				should_persist = NotifyOption::DoPersist;
 			}
 
@@ -10199,10 +10215,13 @@ This indicates a bug inside LDK. Please report this error at https://github.com/
 					chan,
 				);
 
+				let holding_cell_res = self.check_free_peer_holding_cells(peer_state);
+
 				mem::drop(peer_state_lock);
 				mem::drop(per_peer_state);
 
 				self.handle_post_monitor_update_chan_resume(completion_data);
+				self.handle_holding_cell_free_result(holding_cell_res);
 			} else {
 				log_trace!(logger, "Channel is open but not awaiting update");
 			}
@@ -12246,7 +12265,7 @@ This indicates a bug inside LDK. Please report this error at https://github.com/
 
 	#[rustfmt::skip]
 	fn internal_channel_reestablish(&self, counterparty_node_id: &PublicKey, msg: &msgs::ChannelReestablish) -> Result<(), MsgHandleErrInternal> {
-		let (inferred_splice_locked, need_lnd_workaround) = {
+		let (inferred_splice_locked, need_lnd_workaround, holding_cell_res) = {
 			let per_peer_state = self.per_peer_state.read().unwrap();
 
 			let peer_state_mutex = per_peer_state.get(counterparty_node_id)
@@ -12307,7 +12326,8 @@ This indicates a bug inside LDK. Please report this error at https://github.com/
 							peer_state.pending_msg_events.push(upd);
 						}
 
-						(responses.inferred_splice_locked, need_lnd_workaround)
+						let holding_cell_res = self.check_free_peer_holding_cells(peer_state);
+						(responses.inferred_splice_locked, need_lnd_workaround, holding_cell_res)
 					} else {
 						return try_channel_entry!(self, peer_state, Err(ChannelError::close(
 							"Got a channel_reestablish message for an unfunded channel!".into())), chan_entry);
@@ -12349,6 +12369,8 @@ This indicates a bug inside LDK. Please report this error at https://github.com/
 				}
 			}
 		};
+
+		self.handle_holding_cell_free_result(holding_cell_res);
 
 		if let Some(channel_ready_msg) = need_lnd_workaround {
 			self.internal_channel_ready(counterparty_node_id, &channel_ready_msg)?;
@@ -12686,70 +12708,83 @@ This indicates a bug inside LDK. Please report this error at https://github.com/
 		has_pending_monitor_events
 	}
 
+	fn handle_holding_cell_free_result(&self, result: FreeHoldingCellsResult) {
+		debug_assert_ne!(
+			self.total_consistency_lock.held_by_thread(),
+			LockHeldState::NotHeldByThread
+		);
+		for (chan_id, cp_node_id, post_update_data, failed_htlcs) in result {
+			if let Some(data) = post_update_data {
+				self.handle_post_monitor_update_chan_resume(data);
+			}
+
+			self.fail_holding_cell_htlcs(failed_htlcs, chan_id, &cp_node_id);
+			self.needs_persist_flag.store(true, Ordering::Release);
+			self.event_persist_notifier.notify();
+		}
+	}
+
+	/// Frees all holding cells in all the channels for a peer.
+	///
+	/// Includes elements in the returned Vec only for channels which changed (implying persistence
+	/// is required).
+	#[must_use]
+	fn check_free_peer_holding_cells(
+		&self, peer_state: &mut PeerState<SP>,
+	) -> FreeHoldingCellsResult {
+		debug_assert_ne!(
+			self.total_consistency_lock.held_by_thread(),
+			LockHeldState::NotHeldByThread
+		);
+
+		let mut updates = Vec::new();
+		let funded_chan_iter = peer_state
+			.channel_by_id
+			.iter_mut()
+			.filter_map(|(chan_id, chan)| chan.as_funded_mut().map(|chan| (chan_id, chan)));
+		for (chan_id, chan) in funded_chan_iter {
+			let (monitor_opt, holding_cell_failed_htlcs) = chan.maybe_free_holding_cell_htlcs(
+				&self.fee_estimator,
+				&&WithChannelContext::from(&self.logger, &chan.context, None),
+			);
+			if monitor_opt.is_some() || !holding_cell_failed_htlcs.is_empty() {
+				let update_res = monitor_opt
+					.map(|monitor_update| {
+						self.handle_new_monitor_update(
+							&mut peer_state.in_flight_monitor_updates,
+							&mut peer_state.monitor_update_blocked_actions,
+							&mut peer_state.pending_msg_events,
+							peer_state.is_connected,
+							chan,
+							chan.funding.get_funding_txo().unwrap(),
+							monitor_update,
+						)
+					})
+					.flatten();
+				let cp_node_id = chan.context.get_counterparty_node_id();
+				updates.push((*chan_id, cp_node_id, update_res, holding_cell_failed_htlcs));
+			}
+		}
+		updates
+	}
+
 	/// Check the holding cell in each channel and free any pending HTLCs in them if possible.
 	/// Returns whether there were any updates such as if pending HTLCs were freed or a monitor
 	/// update was applied.
 	fn check_free_holding_cells(&self) -> bool {
-		let mut has_monitor_update = false;
-		let mut failed_htlcs = Vec::new();
+		let mut unlocked_results = Vec::new();
 
-		// Walk our list of channels and find any that need to update. Note that when we do find an
-		// update, if it includes actions that must be taken afterwards, we have to drop the
-		// per-peer state lock as well as the top level per_peer_state lock. Thus, we loop until we
-		// manage to go through all our peers without finding a single channel to update.
-		'peer_loop: loop {
+		{
 			let per_peer_state = self.per_peer_state.read().unwrap();
 			for (_cp_id, peer_state_mutex) in per_peer_state.iter() {
-				'chan_loop: loop {
-					let mut peer_state_lock = peer_state_mutex.lock().unwrap();
-					let peer_state: &mut PeerState<_> = &mut *peer_state_lock;
-					for (channel_id, chan) in
-						peer_state.channel_by_id.iter_mut().filter_map(|(chan_id, chan)| {
-							chan.as_funded_mut().map(|chan| (chan_id, chan))
-						}) {
-						let counterparty_node_id = chan.context.get_counterparty_node_id();
-						let funding_txo = chan.funding.get_funding_txo();
-						let (monitor_opt, holding_cell_failed_htlcs) = chan
-							.maybe_free_holding_cell_htlcs(
-								&self.fee_estimator,
-								&&WithChannelContext::from(&self.logger, &chan.context, None),
-							);
-						if !holding_cell_failed_htlcs.is_empty() {
-							failed_htlcs.push((
-								holding_cell_failed_htlcs,
-								*channel_id,
-								counterparty_node_id,
-							));
-						}
-						if let Some(monitor_update) = monitor_opt {
-							has_monitor_update = true;
-
-							if let Some(data) = self.handle_new_monitor_update(
-								&mut peer_state.in_flight_monitor_updates,
-								&mut peer_state.monitor_update_blocked_actions,
-								&mut peer_state.pending_msg_events,
-								peer_state.is_connected,
-								chan,
-								funding_txo.unwrap(),
-								monitor_update,
-							) {
-								mem::drop(peer_state_lock);
-								mem::drop(per_peer_state);
-								self.handle_post_monitor_update_chan_resume(data);
-							}
-							continue 'peer_loop;
-						}
-					}
-					break 'chan_loop;
-				}
+				let mut peer_state_lock = peer_state_mutex.lock().unwrap();
+				let peer_state: &mut PeerState<_> = &mut *peer_state_lock;
+				unlocked_results.append(&mut self.check_free_peer_holding_cells(peer_state));
 			}
-			break 'peer_loop;
 		}
 
-		let has_update = has_monitor_update || !failed_htlcs.is_empty();
-		for (failures, channel_id, counterparty_node_id) in failed_htlcs.drain(..) {
-			self.fail_holding_cell_htlcs(failures, channel_id, &counterparty_node_id);
-		}
+		let has_update = !unlocked_results.is_empty();
+		self.handle_holding_cell_free_result(unlocked_results);
 
 		has_update
 	}
@@ -13081,27 +13116,32 @@ This indicates a bug inside LDK. Please report this error at https://github.com/
 	#[cfg(any(test, fuzzing))]
 	#[rustfmt::skip]
 	pub fn exit_quiescence(&self, counterparty_node_id: &PublicKey, channel_id: &ChannelId) -> Result<bool, APIError> {
-		let per_peer_state = self.per_peer_state.read().unwrap();
-		let peer_state_mutex = per_peer_state.get(counterparty_node_id)
-			.ok_or_else(|| APIError::ChannelUnavailable {
-				err: format!("Can't find a peer matching the passed counterparty node_id {counterparty_node_id}")
-			})?;
-		let mut peer_state = peer_state_mutex.lock().unwrap();
-		let initiator = match peer_state.channel_by_id.entry(*channel_id) {
-			hash_map::Entry::Occupied(mut chan_entry) => {
-				if let Some(chan) = chan_entry.get_mut().as_funded_mut() {
-					chan.exit_quiescence()
-				} else {
-					return Err(APIError::APIMisuseError {
-						err: format!("Unfunded channel {} cannot be quiescent", channel_id),
-					})
-				}
-			},
-			hash_map::Entry::Vacant(_) => return Err(APIError::ChannelUnavailable {
-				err: format!("Channel with id {} not found for the passed counterparty node_id {}",
-					channel_id, counterparty_node_id),
-			}),
+		let _read_guard = self.total_consistency_lock.read().unwrap();
+
+		let initiator = {
+			let per_peer_state = self.per_peer_state.read().unwrap();
+			let peer_state_mutex = per_peer_state.get(counterparty_node_id)
+				.ok_or_else(|| APIError::ChannelUnavailable {
+					err: format!("Can't find a peer matching the passed counterparty node_id {counterparty_node_id}")
+				})?;
+			let mut peer_state = peer_state_mutex.lock().unwrap();
+			match peer_state.channel_by_id.entry(*channel_id) {
+				hash_map::Entry::Occupied(mut chan_entry) => {
+					if let Some(chan) = chan_entry.get_mut().as_funded_mut() {
+						chan.exit_quiescence()
+					} else {
+						return Err(APIError::APIMisuseError {
+							err: format!("Unfunded channel {} cannot be quiescent", channel_id),
+						})
+					}
+				},
+				hash_map::Entry::Vacant(_) => return Err(APIError::ChannelUnavailable {
+					err: format!("Channel with id {} not found for the passed counterparty node_id {}",
+						channel_id, counterparty_node_id),
+				}),
+			}
 		};
+		self.check_free_holding_cells();
 		Ok(initiator)
 	}
 
@@ -14165,7 +14205,7 @@ where
 						if let Some((monitor_update, further_update_exists)) = chan.unblock_next_blocked_monitor_update() {
 							log_debug!(logger, "Unlocking monitor updating and updating monitor",
 								);
-							if let Some(data) = self.handle_new_monitor_update(
+							let post_update_data = self.handle_new_monitor_update(
 								&mut peer_state.in_flight_monitor_updates,
 								&mut peer_state.monitor_update_blocked_actions,
 								&mut peer_state.pending_msg_events,
@@ -14173,11 +14213,18 @@ where
 								chan,
 								channel_funding_outpoint,
 								monitor_update,
-							) {
-								mem::drop(peer_state_lck);
-								mem::drop(per_peer_state);
+							);
+							let holding_cell_res = self.check_free_peer_holding_cells(peer_state);
+
+							mem::drop(peer_state_lck);
+							mem::drop(per_peer_state);
+
+							if let Some(data) = post_update_data {
 								self.handle_post_monitor_update_chan_resume(data);
 							}
+
+							self.handle_holding_cell_free_result(holding_cell_res);
+
 							if further_update_exists {
 								// If there are more `ChannelMonitorUpdate`s to process, restart at the
 								// top of the loop.
@@ -14596,17 +14643,30 @@ where
 		PersistenceNotifierGuard::optionally_notify(self, || {
 			let mut result = NotifyOption::SkipPersistNoEvents;
 
+			// This method is quite performance-sensitive. Not only is it called very often, but it
+			// *is* the critical path between generating a message for a peer and giving it to the
+			// `PeerManager` to send. Thus, we should avoid adding any more logic here than we
+			// need, especially anything that might end up causing I/O (like a
+			// `ChannelMonitorUpdate`)!
+
 			// TODO: This behavior should be documented. It's unintuitive that we query
 			// ChannelMonitors when clearing other events.
 			if self.process_pending_monitor_events() {
 				result = NotifyOption::DoPersist;
 			}
 
-			if self.check_free_holding_cells() {
-				result = NotifyOption::DoPersist;
-			}
 			if self.maybe_generate_initial_closing_signed() {
 				result = NotifyOption::DoPersist;
+			}
+
+			#[cfg(test)]
+			if self.check_free_holding_cells() {
+				// In tests, we want to ensure that we never forget to free holding cells
+				// immediately, so we check it here.
+				// Note that we can't turn this on for `debug_assertions` because there's a race in
+				// (at least) the fee-update logic in `timer_tick_occurred` which can lead to us
+				// freeing holding cells here while its running.
+				debug_assert!(false, "Holding cells should always be auto-free'd");
 			}
 
 			// Quiescence is an in-memory protocol, so we don't have to persist because of it.

--- a/lightning/src/ln/channelmanager.rs
+++ b/lightning/src/ln/channelmanager.rs
@@ -2230,7 +2230,7 @@ where
 ///     match event {
 ///         Event::PaymentClaimable { payment_hash, purpose, .. } => match purpose {
 ///             PaymentPurpose::Bolt11InvoicePayment { payment_preimage: Some(payment_preimage), .. } => {
-///                 assert_eq!(payment_hash.0, invoice.payment_hash().as_ref());
+///                 assert_eq!(payment_hash, invoice.payment_hash());
 ///                 println!("Claiming payment {}", payment_hash);
 ///                 channel_manager.claim_funds(payment_preimage);
 ///             },
@@ -2238,7 +2238,7 @@ where
 ///                 println!("Unknown payment hash: {}", payment_hash);
 ///             },
 ///             PaymentPurpose::SpontaneousPayment(payment_preimage) => {
-///                 assert_ne!(payment_hash.0, invoice.payment_hash().as_ref());
+///                 assert_ne!(payment_hash, invoice.payment_hash());
 ///                 println!("Claiming spontaneous payment {}", payment_hash);
 ///                 channel_manager.claim_funds(payment_preimage);
 ///             },
@@ -2246,7 +2246,7 @@ where
 /// #           _ => {},
 ///         },
 ///         Event::PaymentClaimed { payment_hash, amount_msat, .. } => {
-///             assert_eq!(payment_hash.0, invoice.payment_hash().as_ref());
+///             assert_eq!(payment_hash, invoice.payment_hash());
 ///             println!("Claimed {} msats", amount_msat);
 ///         },
 ///         // ...
@@ -2271,7 +2271,7 @@ where
 /// # ) {
 /// # let channel_manager = channel_manager.get_cm();
 /// # let payment_id = PaymentId([42; 32]);
-/// # let payment_hash = PaymentHash((*invoice.payment_hash()).to_byte_array());
+/// # let payment_hash = invoice.payment_hash();
 /// match channel_manager.pay_for_bolt11_invoice(
 ///     invoice, payment_id, None, route_params_config, retry
 /// ) {

--- a/lightning/src/ln/channelmanager.rs
+++ b/lightning/src/ln/channelmanager.rs
@@ -4193,6 +4193,7 @@ where
 							their_features,
 							target_feerate_sats_per_1000_weight,
 							override_shutdown_script,
+							&self.logger,
 						)?;
 						failed_htlcs = htlcs;
 
@@ -11231,7 +11232,12 @@ This indicates a bug inside LDK. Please report this error at https://github.com/
 						let (shutdown, monitor_update_opt, htlcs) = try_channel_entry!(
 							self,
 							peer_state,
-							chan.shutdown(&self.signer_provider, &peer_state.latest_features, &msg),
+							chan.shutdown(
+								&self.logger,
+								&self.signer_provider,
+								&peer_state.latest_features,
+								&msg
+							),
 							chan_entry
 						);
 						dropped_htlcs = htlcs;

--- a/lightning/src/ln/channelmanager.rs
+++ b/lightning/src/ln/channelmanager.rs
@@ -770,6 +770,12 @@ mod fuzzy_channelmanager {
 			/// we can provide proof-of-payment details in payment claim events even after a restart
 			/// with a stale ChannelManager state.
 			bolt12_invoice: Option<PaidBolt12Invoice>,
+			/// The [`Nonce`] used when the BOLT 12 [`InvoiceRequest`] was created. Stored here so
+			/// it can be included in [`Event::PaymentSent`] for building payer proofs, even after
+			/// a restart with a stale `ChannelManager` state.
+			///
+			/// [`InvoiceRequest`]: crate::offers::invoice_request::InvoiceRequest
+			payment_nonce: Option<Nonce>,
 		},
 	}
 
@@ -813,6 +819,7 @@ impl core::hash::Hash for HTLCSource {
 				payment_id,
 				first_hop_htlc_msat,
 				bolt12_invoice,
+				..
 			} => {
 				1u8.hash(hasher);
 				path.hash(hasher);
@@ -833,6 +840,7 @@ impl HTLCSource {
 			first_hop_htlc_msat: 0,
 			payment_id: PaymentId([2; 32]),
 			bolt12_invoice: None,
+			payment_nonce: None,
 		}
 	}
 
@@ -5174,6 +5182,7 @@ where
 			keysend_preimage,
 			invoice_request: None,
 			bolt12_invoice: None,
+			payment_nonce: None,
 			session_priv_bytes,
 			hold_htlc_at_next_hop: false,
 		})
@@ -5190,6 +5199,7 @@ where
 			keysend_preimage,
 			invoice_request,
 			bolt12_invoice,
+			payment_nonce,
 			session_priv_bytes,
 			hold_htlc_at_next_hop,
 		} = args;
@@ -5273,6 +5283,7 @@ where
 							first_hop_htlc_msat: htlc_msat,
 							payment_id,
 							bolt12_invoice: bolt12_invoice.cloned(),
+							payment_nonce: payment_nonce.copied(),
 						};
 						let send_res = chan.send_htlc_and_commit(
 							htlc_msat,
@@ -5548,14 +5559,19 @@ where
 	pub fn send_payment_for_bolt12_invoice(
 		&self, invoice: &Bolt12Invoice, context: Option<&OffersContext>,
 	) -> Result<(), Bolt12PaymentError> {
+		let nonce = context.and_then(|ctx| match ctx {
+			OffersContext::OutboundPaymentForOffer { nonce, .. }
+			| OffersContext::OutboundPaymentForRefund { nonce, .. } => Some(*nonce),
+			_ => None,
+		});
 		match self.flow.verify_bolt12_invoice(invoice, context) {
-			Ok(payment_id) => self.send_payment_for_verified_bolt12_invoice(invoice, payment_id),
+			Ok(payment_id) => self.send_payment_for_verified_bolt12_invoice(invoice, payment_id, nonce),
 			Err(()) => Err(Bolt12PaymentError::UnexpectedInvoice),
 		}
 	}
 
 	fn send_payment_for_verified_bolt12_invoice(
-		&self, invoice: &Bolt12Invoice, payment_id: PaymentId,
+		&self, invoice: &Bolt12Invoice, payment_id: PaymentId, payment_nonce: Option<Nonce>,
 	) -> Result<(), Bolt12PaymentError> {
 		let best_block_height = self.best_block.read().unwrap().height;
 		let _persistence_guard = PersistenceNotifierGuard::notify_on_drop(self);
@@ -5563,6 +5579,7 @@ where
 		self.pending_outbound_payments.send_payment_for_bolt12_invoice(
 			invoice,
 			payment_id,
+			payment_nonce,
 			&self.router,
 			self.list_usable_channels(),
 			features,
@@ -9244,7 +9261,7 @@ This indicates a bug inside LDK. Please report this error at https://github.com/
 		let htlc_id = SentHTLCId::from_source(&source);
 		match source {
 			HTLCSource::OutboundRoute {
-				session_priv, payment_id, path, bolt12_invoice, ..
+				session_priv, payment_id, path, bolt12_invoice, payment_nonce, ..
 			} => {
 				debug_assert!(!startup_replay,
 					"We don't support claim_htlc claims during startup - monitors may not be available yet");
@@ -9269,6 +9286,7 @@ This indicates a bug inside LDK. Please report this error at https://github.com/
 					payment_id,
 					payment_preimage,
 					bolt12_invoice,
+					payment_nonce,
 					session_priv,
 					path,
 					from_onchain,
@@ -16163,7 +16181,12 @@ where
 					return None;
 				}
 
-				let res = self.send_payment_for_verified_bolt12_invoice(&invoice, payment_id);
+				let payment_nonce = context.as_ref().and_then(|ctx| match ctx {
+					OffersContext::OutboundPaymentForOffer { nonce, .. }
+					| OffersContext::OutboundPaymentForRefund { nonce, .. } => Some(*nonce),
+					_ => None,
+				});
+				let res = self.send_payment_for_verified_bolt12_invoice(&invoice, payment_id, payment_nonce);
 				handle_pay_invoice_res!(res, invoice, logger);
 			},
 			OffersMessage::StaticInvoice(invoice) => {
@@ -16827,6 +16850,7 @@ impl Readable for HTLCSource {
 				let mut payment_params: Option<PaymentParameters> = None;
 				let mut blinded_tail: Option<BlindedTail> = None;
 				let mut bolt12_invoice: Option<PaidBolt12Invoice> = None;
+				let mut payment_nonce: Option<Nonce> = None;
 				read_tlv_fields!(reader, {
 					(0, session_priv, required),
 					(1, payment_id, option),
@@ -16835,6 +16859,7 @@ impl Readable for HTLCSource {
 					(5, payment_params, (option: ReadableArgs, 0)),
 					(6, blinded_tail, option),
 					(7, bolt12_invoice, option),
+					(9, payment_nonce, option),
 				});
 				if payment_id.is_none() {
 					// For backwards compat, if there was no payment_id written, use the session_priv bytes
@@ -16858,6 +16883,7 @@ impl Readable for HTLCSource {
 					path,
 					payment_id: payment_id.unwrap(),
 					bolt12_invoice,
+					payment_nonce,
 				})
 			}
 			1 => Ok(HTLCSource::PreviousHopData(Readable::read(reader)?)),
@@ -16875,6 +16901,7 @@ impl Writeable for HTLCSource {
 				ref path,
 				payment_id,
 				bolt12_invoice,
+				payment_nonce,
 			} => {
 				0u8.write(writer)?;
 				let payment_id_opt = Some(payment_id);
@@ -16887,6 +16914,7 @@ impl Writeable for HTLCSource {
 				   (5, None::<PaymentParameters>, option), // payment_params in LDK versions prior to 0.0.115
 				   (6, path.blinded_tail, option),
 				   (7, bolt12_invoice, option),
+				   (9, payment_nonce, option),
 				});
 			},
 			HTLCSource::PreviousHopData(ref field) => {
@@ -18497,6 +18525,7 @@ where
 							session_priv,
 							path,
 							bolt12_invoice,
+							payment_nonce,
 							..
 						} => {
 							if !is_channel_closed {
@@ -18517,6 +18546,7 @@ where
 									payment_id,
 									preimage,
 									bolt12_invoice,
+									payment_nonce,
 									session_priv,
 									path,
 									true,

--- a/lightning/src/ln/functional_test_utils.rs
+++ b/lightning/src/ln/functional_test_utils.rs
@@ -4563,7 +4563,29 @@ pub fn create_network<'a, 'b: 'a, 'c: 'b>(
 	let mut nodes = Vec::new();
 	let chan_count = Rc::new(RefCell::new(0));
 	let payment_count = Rc::new(RefCell::new(0));
-	let connect_style = Rc::new(RefCell::new(ConnectStyle::random_style()));
+
+	let connect_style = Rc::new(RefCell::new(match std::env::var("LDK_TEST_CONNECT_STYLE") {
+		Ok(val) => match val.as_str() {
+			"BEST_BLOCK_FIRST" => ConnectStyle::BestBlockFirst,
+			"BEST_BLOCK_FIRST_SKIPPING_BLOCKS" => ConnectStyle::BestBlockFirstSkippingBlocks,
+			"BEST_BLOCK_FIRST_REORGS_ONLY_TIP" => ConnectStyle::BestBlockFirstReorgsOnlyTip,
+			"TRANSACTIONS_FIRST" => ConnectStyle::TransactionsFirst,
+			"TRANSACTIONS_FIRST_SKIPPING_BLOCKS" => ConnectStyle::TransactionsFirstSkippingBlocks,
+			"TRANSACTIONS_DUPLICATIVELY_FIRST_SKIPPING_BLOCKS" => {
+				ConnectStyle::TransactionsDuplicativelyFirstSkippingBlocks
+			},
+			"HIGHLY_REDUNDANT_TRANSACTIONS_FIRST_SKIPPING_BLOCKS" => {
+				ConnectStyle::HighlyRedundantTransactionsFirstSkippingBlocks
+			},
+			"TRANSACTIONS_FIRST_REORGS_ONLY_TIP" => ConnectStyle::TransactionsFirstReorgsOnlyTip,
+			"FULL_BLOCK_VIA_LISTEN" => ConnectStyle::FullBlockViaListen,
+			"FULL_BLOCK_DISCONNECTIONS_SKIPPING_VIA_LISTEN" => {
+				ConnectStyle::FullBlockDisconnectionsSkippingViaListen
+			},
+			_ => panic!("Unknown ConnectStyle '{}'", val),
+		},
+		Err(_) => ConnectStyle::random_style(),
+	}));
 
 	for i in 0..node_count {
 		let dedicated_entropy = DedicatedEntropy(RandomBytes::new([i as u8; 32]));

--- a/lightning/src/ln/functional_test_utils.rs
+++ b/lightning/src/ln/functional_test_utils.rs
@@ -971,7 +971,7 @@ pub fn get_revoke_commit_msgs<CM: AChannelManager, H: NodeHolder<CM = CM>>(
 				assert_eq!(node_id, recipient);
 				(*msg).clone()
 			},
-			_ => panic!("Unexpected event"),
+			_ => panic!("Unexpected event: {events:?}"),
 		},
 		match events[1] {
 			MessageSendEvent::UpdateHTLCs { ref node_id, ref channel_id, ref updates } => {
@@ -984,7 +984,7 @@ pub fn get_revoke_commit_msgs<CM: AChannelManager, H: NodeHolder<CM = CM>>(
 				assert!(updates.commitment_signed.iter().all(|cs| cs.channel_id == *channel_id));
 				updates.commitment_signed.clone()
 			},
-			_ => panic!("Unexpected event"),
+			_ => panic!("Unexpected event: {events:?}"),
 		},
 	)
 }

--- a/lightning/src/ln/functional_test_utils.rs
+++ b/lightning/src/ln/functional_test_utils.rs
@@ -2986,6 +2986,7 @@ pub fn expect_payment_sent<CM: AChannelManager, H: NodeHolder<CM = CM>>(
 			ref amount_msat,
 			ref fee_paid_msat,
 			ref bolt12_invoice,
+			..
 		} => {
 			assert_eq!(expected_payment_preimage, *payment_preimage);
 			assert_eq!(expected_payment_hash, *payment_hash);

--- a/lightning/src/ln/functional_tests.rs
+++ b/lightning/src/ln/functional_tests.rs
@@ -2270,6 +2270,7 @@ pub fn fail_backward_pending_htlc_upon_channel_failure() {
 			skimmed_fee_msat: None,
 			blinding_point: None,
 			hold_htlc: None,
+			accountable: None,
 		};
 		nodes[0].node.handle_update_add_htlc(node_b_id, &update_add_htlc);
 	}

--- a/lightning/src/ln/htlc_reserve_unit_tests.rs
+++ b/lightning/src/ln/htlc_reserve_unit_tests.rs
@@ -839,6 +839,7 @@ pub fn do_test_fee_spike_buffer(cfg: Option<UserConfig>, htlc_fails: bool) {
 		skimmed_fee_msat: None,
 		blinding_point: None,
 		hold_htlc: None,
+		accountable: None,
 	};
 
 	nodes[1].node.handle_update_add_htlc(node_a_id, &msg);
@@ -1082,6 +1083,7 @@ pub fn test_chan_reserve_violation_inbound_htlc_outbound_channel() {
 		skimmed_fee_msat: None,
 		blinding_point: None,
 		hold_htlc: None,
+		accountable: None,
 	};
 
 	nodes[0].node.handle_update_add_htlc(node_b_id, &msg);
@@ -1266,6 +1268,7 @@ pub fn test_chan_reserve_violation_inbound_htlc_inbound_chan() {
 		skimmed_fee_msat: None,
 		blinding_point: None,
 		hold_htlc: None,
+		accountable: None,
 	};
 
 	nodes[1].node.handle_update_add_htlc(node_a_id, &msg);
@@ -1650,6 +1653,7 @@ pub fn test_update_add_htlc_bolt2_receiver_check_max_htlc_limit() {
 		skimmed_fee_msat: None,
 		blinding_point: None,
 		hold_htlc: None,
+		accountable: None,
 	};
 
 	for i in 0..50 {
@@ -2256,6 +2260,7 @@ pub fn do_test_dust_limit_fee_accounting(can_afford: bool) {
 		skimmed_fee_msat: None,
 		blinding_point: None,
 		hold_htlc: None,
+		accountable: None,
 	};
 
 	nodes[1].node.handle_update_add_htlc(node_a_id, &msg);

--- a/lightning/src/ln/invoice_utils.rs
+++ b/lightning/src/ln/invoice_utils.rs
@@ -627,7 +627,7 @@ mod test {
 	use crate::util::dyn_signer::{DynKeysInterface, DynPhantomKeysInterface};
 	use crate::util::test_utils;
 	use bitcoin::hashes::sha256::Hash as Sha256;
-	use bitcoin::hashes::{sha256, Hash};
+	use bitcoin::hashes::Hash;
 	use bitcoin::network::Network;
 	use core::time::Duration;
 	use lightning_invoice::{
@@ -829,7 +829,7 @@ mod test {
 			invoice.description(),
 			Bolt11InvoiceDescriptionRef::Direct(&Description::new("test".to_string()).unwrap())
 		);
-		assert_eq!(invoice.payment_hash(), &sha256::Hash::from_slice(&payment_hash.0[..]).unwrap());
+		assert_eq!(invoice.payment_hash(), payment_hash);
 	}
 
 	#[cfg(not(feature = "std"))]
@@ -1257,8 +1257,7 @@ mod test {
 			Duration::from_secs(genesis_timestamp),
 		)
 		.unwrap();
-		let (payment_hash, payment_secret) =
-			(PaymentHash(invoice.payment_hash().to_byte_array()), *invoice.payment_secret());
+		let (payment_hash, payment_secret) = (invoice.payment_hash(), *invoice.payment_secret());
 		let payment_preimage = if user_generated_pmt_hash {
 			user_payment_preimage
 		} else {
@@ -1290,7 +1289,7 @@ mod test {
 			invoice.amount_milli_satoshis().unwrap(),
 		);
 
-		let payment_hash = PaymentHash(invoice.payment_hash().to_byte_array());
+		let payment_hash = invoice.payment_hash();
 		let id = PaymentId(payment_hash.0);
 		let onion = RecipientOnionFields::secret_only(*invoice.payment_secret());
 		nodes[0].node.send_payment(payment_hash, onion, id, params, Retry::Attempts(0)).unwrap();

--- a/lightning/src/ln/mod.rs
+++ b/lightning/src/ln/mod.rs
@@ -53,6 +53,8 @@ pub(crate) mod interactivetxs;
 // about an unnecessary mut. Thus, we silence the unused_mut warning in two test modules below.
 
 #[cfg(test)]
+mod accountable_tests;
+#[cfg(test)]
 #[allow(unused_mut)]
 mod async_payments_tests;
 #[cfg(test)]

--- a/lightning/src/ln/offers_tests.rs
+++ b/lightning/src/ln/offers_tests.rs
@@ -185,7 +185,20 @@ fn route_bolt12_payment<'a, 'b, 'c>(
 fn claim_bolt12_payment<'a, 'b, 'c>(
 	node: &Node<'a, 'b, 'c>, path: &[&Node<'a, 'b, 'c>], expected_payment_context: PaymentContext, invoice: &Bolt12Invoice
 ) {
-	let recipient = &path[path.len() - 1];
+	claim_bolt12_payment_with_extra_fees(
+		node,
+		path,
+		expected_payment_context,
+		invoice,
+		None,
+	)
+}
+
+fn claim_bolt12_payment_with_extra_fees<'a, 'b, 'c>(
+	node: &Node<'a, 'b, 'c>, path: &[&Node<'a, 'b, 'c>], expected_payment_context: PaymentContext, invoice: &Bolt12Invoice,
+	expected_extra_fees_msat: Option<u64>,
+) {
+	let recipient = path.last().expect("Empty path?");
 	let payment_purpose = match get_event!(recipient, Event::PaymentClaimable) {
 		Event::PaymentClaimable { purpose, .. } => purpose,
 		_ => panic!("No Event::PaymentClaimable"),
@@ -194,20 +207,29 @@ fn claim_bolt12_payment<'a, 'b, 'c>(
 		Some(preimage) => preimage,
 		None => panic!("No preimage in Event::PaymentClaimable"),
 	};
-	match payment_purpose {
-		PaymentPurpose::Bolt12OfferPayment { payment_context, .. } => {
-			assert_eq!(PaymentContext::Bolt12Offer(payment_context), expected_payment_context);
-		},
-		PaymentPurpose::Bolt12RefundPayment { payment_context, .. } => {
-			assert_eq!(PaymentContext::Bolt12Refund(payment_context), expected_payment_context);
-		},
+	let context = match payment_purpose {
+		PaymentPurpose::Bolt12OfferPayment { payment_context, .. } =>
+			PaymentContext::Bolt12Offer(payment_context),
+		PaymentPurpose::Bolt12RefundPayment { payment_context, .. } =>
+			PaymentContext::Bolt12Refund(payment_context),
 		_ => panic!("Unexpected payment purpose: {:?}", payment_purpose),
-	}
-	if let Some(inv) = claim_payment(node, path, payment_preimage) {
-		assert_eq!(inv, PaidBolt12Invoice::Bolt12Invoice(invoice.to_owned()));
-	} else {
-		panic!("Expected PaidInvoice::Bolt12Invoice");
 	};
+
+	assert_eq!(context, expected_payment_context);
+
+	let expected_paths = [path];
+	let mut args = ClaimAlongRouteArgs::new(
+		node,
+		&expected_paths,
+		payment_preimage,
+	);
+
+	if let Some(extra) = expected_extra_fees_msat {
+		args = args.with_expected_extra_total_fees_msat(extra);
+	}
+
+	let (inv, _) = claim_payment_along_route(args);
+	assert_eq!(inv, Some(PaidBolt12Invoice::Bolt12Invoice(invoice.clone())));
 }
 
 fn extract_offer_nonce<'a, 'b, 'c>(node: &Node<'a, 'b, 'c>, message: &OnionMessage) -> Nonce {

--- a/lightning/src/ln/offers_tests.rs
+++ b/lightning/src/ln/offers_tests.rs
@@ -47,7 +47,7 @@ use bitcoin::secp256k1::{PublicKey, Secp256k1};
 use core::time::Duration;
 use crate::blinded_path::IntroductionNode;
 use crate::blinded_path::message::BlindedMessagePath;
-use crate::blinded_path::payment::{Bolt12OfferContext, Bolt12RefundContext, PaymentContext};
+use crate::blinded_path::payment::{Bolt12OfferContext, Bolt12RefundContext, DummyTlvs, PaymentContext};
 use crate::blinded_path::message::OffersContext;
 use crate::events::{ClosureReason, Event, HTLCHandlingFailureType, PaidBolt12Invoice, PaymentFailureReason, PaymentPurpose};
 use crate::ln::channelmanager::{Bolt12PaymentError, PaymentId, RecentPaymentDetails, RecipientOnionFields, Retry, self};
@@ -63,7 +63,7 @@ use crate::offers::parse::Bolt12SemanticError;
 use crate::onion_message::messenger::{DefaultMessageRouter, Destination, MessageSendInstructions, NodeIdMessageRouter, NullMessageRouter, PeeledOnion, PADDED_PATH_LENGTH};
 use crate::onion_message::offers::OffersMessage;
 use crate::routing::gossip::{NodeAlias, NodeId};
-use crate::routing::router::{PaymentParameters, RouteParameters, RouteParametersConfig};
+use crate::routing::router::{DEFAULT_PAYMENT_DUMMY_HOPS, PaymentParameters, RouteParameters, RouteParametersConfig};
 use crate::sign::{NodeSigner, Recipient};
 use crate::util::ser::Writeable;
 
@@ -178,7 +178,8 @@ fn route_bolt12_payment<'a, 'b, 'c>(
 	let amount_msats = invoice.amount_msats();
 	let payment_hash = invoice.payment_hash();
 	let args = PassAlongPathArgs::new(node, path, amount_msats, payment_hash, ev)
-		.without_clearing_recipient_events();
+		.without_clearing_recipient_events()
+		.with_dummy_tlvs(&[DummyTlvs::default(); DEFAULT_PAYMENT_DUMMY_HOPS]);
 	do_pass_along_path(args);
 }
 
@@ -1432,7 +1433,20 @@ fn creates_offer_with_blinded_path_using_unannounced_introduction_node() {
 	route_bolt12_payment(bob, &[alice], &invoice);
 	expect_recent_payment!(bob, RecentPaymentDetails::Pending, payment_id);
 
-	claim_bolt12_payment(bob, &[alice], payment_context, &invoice);
+	// When the payer is the introduction node of a blinded path, LDK doesn't
+	// subtract the forward fee for the `payer -> next_hop` channel (see
+	// `BlindedPaymentPath::advance_path_by_one`). This keeps fee logic simple,
+	// at the cost of a small, intentional overpayment.
+	//
+	// In the old two-hop case (payer as introduction node → payee), this never
+	// surfaced because the payer simply wasn’t charged the forward fee.
+	//
+	// With dummy hops in LDK v0.3, even a real two-node path can appear as a
+	// longer blinded route, so the overpayment shows up in tests.
+	//
+	// Until the fee-handling trade-off is revisited, we pass an expected extra
+	// fee here so tests can compensate for it.
+	claim_bolt12_payment_with_extra_fees(bob, &[alice], payment_context, &invoice, Some(1000));
 	expect_recent_payment!(bob, RecentPaymentDetails::Fulfilled, payment_id);
 }
 
@@ -2444,12 +2458,13 @@ fn rejects_keysend_to_non_static_invoice_path() {
 
 	let args = PassAlongPathArgs::new(&nodes[0], route[0], amt_msat, payment_hash, ev)
 		.with_payment_preimage(payment_preimage)
-		.expect_failure(HTLCHandlingFailureType::Receive { payment_hash });
+		.expect_failure(HTLCHandlingFailureType::Receive { payment_hash })
+		.with_dummy_tlvs(&[DummyTlvs::default(); DEFAULT_PAYMENT_DUMMY_HOPS]);
 	do_pass_along_path(args);
 	let mut updates = get_htlc_update_msgs(&nodes[1], &nodes[0].node.get_our_node_id());
-	nodes[0].node.handle_update_fail_htlc(nodes[1].node.get_our_node_id(), &updates.update_fail_htlcs[0]);
+	nodes[0].node.handle_update_fail_malformed_htlc(nodes[1].node.get_our_node_id(), &updates.update_fail_malformed_htlcs[0]);
 	do_commitment_signed_dance(&nodes[0], &nodes[1], &updates.commitment_signed, false, false);
-	expect_payment_failed_conditions(&nodes[0], payment_hash, true, PaymentFailedConditions::new());
+	expect_payment_failed_conditions(&nodes[0], payment_hash, false, PaymentFailedConditions::new());
 }
 
 #[test]
@@ -2508,12 +2523,14 @@ fn no_double_pay_with_stale_channelmanager() {
 
 	let ev = remove_first_msg_event_to_node(&bob_id, &mut events);
 	let args = PassAlongPathArgs::new(&nodes[0], expected_route[0], amt_msat, payment_hash, ev)
-		.without_clearing_recipient_events();
+		.without_clearing_recipient_events()
+		.with_dummy_tlvs(&[DummyTlvs::default(); DEFAULT_PAYMENT_DUMMY_HOPS]);
 	do_pass_along_path(args);
 
 	let ev = remove_first_msg_event_to_node(&bob_id, &mut events);
 	let args = PassAlongPathArgs::new(&nodes[0], expected_route[0], amt_msat, payment_hash, ev)
-		.without_clearing_recipient_events();
+		.without_clearing_recipient_events()
+		.with_dummy_tlvs(&[DummyTlvs::default(); DEFAULT_PAYMENT_DUMMY_HOPS]);
 	do_pass_along_path(args);
 
 	expect_recent_payment!(nodes[0], RecentPaymentDetails::Pending, payment_id);

--- a/lightning/src/ln/onion_payment.rs
+++ b/lightning/src/ln/onion_payment.rs
@@ -814,6 +814,7 @@ mod tests {
 			skimmed_fee_msat: None,
 			blinding_point: None,
 			hold_htlc: None,
+			accountable: None,
 		}
 	}
 

--- a/lightning/src/ln/onion_payment.rs
+++ b/lightning/src/ln/onion_payment.rs
@@ -267,6 +267,7 @@ pub(super) fn create_fwd_pending_htlc_info(
 		outgoing_amt_msat: amt_to_forward,
 		outgoing_cltv_value,
 		skimmed_fee_msat: None,
+		incoming_accountable: msg.accountable.unwrap_or(false),
 	})
 }
 
@@ -274,7 +275,7 @@ pub(super) fn create_fwd_pending_htlc_info(
 pub(super) fn create_recv_pending_htlc_info(
 	hop_data: onion_utils::Hop, shared_secret: [u8; 32], payment_hash: PaymentHash,
 	amt_msat: u64, cltv_expiry: u32, phantom_shared_secret: Option<[u8; 32]>, allow_underpay: bool,
-	counterparty_skimmed_fee_msat: Option<u64>, current_height: u32
+	counterparty_skimmed_fee_msat: Option<u64>, incoming_accountable: bool, current_height: u32
 ) -> Result<PendingHTLCInfo, InboundHTLCErr> {
 	let (
 		payment_data, keysend_preimage, custom_tlvs, onion_amt_msat, onion_cltv_expiry,
@@ -456,6 +457,7 @@ pub(super) fn create_recv_pending_htlc_info(
 		outgoing_amt_msat: onion_amt_msat,
 		outgoing_cltv_value: onion_cltv_expiry,
 		skimmed_fee_msat: counterparty_skimmed_fee_msat,
+		incoming_accountable,
 	})
 }
 
@@ -520,7 +522,8 @@ where
 			let shared_secret = hop.shared_secret().secret_bytes();
 			create_recv_pending_htlc_info(
 				hop, shared_secret, msg.payment_hash, msg.amount_msat, msg.cltv_expiry,
-				None, allow_skimmed_fees, msg.skimmed_fee_msat, cur_height,
+				None, allow_skimmed_fees, msg.skimmed_fee_msat,
+				msg.accountable.unwrap_or(false), cur_height,
 			)?
 		}
 	})

--- a/lightning/src/ln/onion_payment.rs
+++ b/lightning/src/ln/onion_payment.rs
@@ -149,6 +149,14 @@ pub(super) fn create_fwd_pending_htlc_info(
 			(RoutingInfo::Direct { short_channel_id, new_packet_bytes, next_hop_hmac }, amt_to_forward, outgoing_cltv_value, intro_node_blinding_point,
 				next_blinding_override)
 		},
+		onion_utils::Hop::Dummy { .. } => {
+			debug_assert!(false, "Dummy hop should have been peeled earlier");
+			return Err(InboundHTLCErr {
+				msg: "Dummy Hop OnionHopData provided for us as an intermediary node",
+				reason: LocalHTLCFailureReason::InvalidOnionPayload,
+				err_data: Vec::new(),
+			})
+		},
 		onion_utils::Hop::Receive { .. } | onion_utils::Hop::BlindedReceive { .. } =>
 			return Err(InboundHTLCErr {
 				msg: "Final Node OnionHopData provided for us as an intermediary node",
@@ -364,6 +372,14 @@ pub(super) fn create_recv_pending_htlc_info(
 				msg: "Got blinded non final data with an HMAC of 0",
 			})
 		},
+		onion_utils::Hop::Dummy { .. } => {
+			debug_assert!(false, "Dummy hop should have been peeled earlier");
+			return Err(InboundHTLCErr {
+				reason: LocalHTLCFailureReason::InvalidOnionBlinding,
+				err_data: vec![0; 32],
+				msg: "Got blinded non final data with an HMAC of 0",
+			})
+		}
 		onion_utils::Hop::TrampolineForward { .. } | onion_utils::Hop::TrampolineBlindedForward { .. } => {
 			return Err(InboundHTLCErr {
 				reason: LocalHTLCFailureReason::InvalidOnionPayload,

--- a/lightning/src/ln/onion_utils.rs
+++ b/lightning/src/ln/onion_utils.rs
@@ -2223,6 +2223,17 @@ pub(crate) enum Hop {
 		/// Bytes of the onion packet we're forwarding.
 		new_packet_bytes: [u8; ONION_DATA_LEN],
 	},
+	/// This onion payload is dummy, and needs to be peeled by us.
+	Dummy {
+		/// Blinding point for introduction-node dummy hops.
+		dummy_hop_data: msgs::InboundOnionDummyPayload,
+		/// Shared secret for decrypting the next-hop public key.
+		shared_secret: SharedSecret,
+		/// HMAC of the next hop's onion packet.
+		next_hop_hmac: [u8; 32],
+		/// Onion packet bytes after this dummy layer is peeled.
+		new_packet_bytes: [u8; ONION_DATA_LEN],
+	},
 	/// This onion payload was for us, not for forwarding to a next-hop. Contains information for
 	/// verifying the incoming payment.
 	Receive {
@@ -2277,6 +2288,7 @@ impl Hop {
 		match self {
 			Hop::Forward { shared_secret, .. } => shared_secret,
 			Hop::BlindedForward { shared_secret, .. } => shared_secret,
+			Hop::Dummy { shared_secret, .. } => shared_secret,
 			Hop::TrampolineForward { outer_shared_secret, .. } => outer_shared_secret,
 			Hop::TrampolineBlindedForward { outer_shared_secret, .. } => outer_shared_secret,
 			Hop::Receive { shared_secret, .. } => shared_secret,

--- a/lightning/src/ln/onion_utils.rs
+++ b/lightning/src/ln/onion_utils.rs
@@ -3531,6 +3531,7 @@ mod tests {
 			first_hop_htlc_msat: 0,
 			payment_id: PaymentId([1; 32]),
 			bolt12_invoice: None,
+			payment_nonce: None,
 		};
 
 		process_onion_failure(&ctx_full, &logger, &htlc_source, onion_error)
@@ -3717,6 +3718,7 @@ mod tests {
 				first_hop_htlc_msat: dummy_amt_msat,
 				payment_id: PaymentId([1; 32]),
 				bolt12_invoice: None,
+				payment_nonce: None,
 			};
 
 			{
@@ -3905,6 +3907,7 @@ mod tests {
 			first_hop_htlc_msat: 0,
 			payment_id: PaymentId([1; 32]),
 			bolt12_invoice: None,
+			payment_nonce: None,
 		};
 
 		// Iterate over all possible failure positions and check that the cases that can be attributed are.
@@ -4014,6 +4017,7 @@ mod tests {
 			first_hop_htlc_msat: 0,
 			payment_id: PaymentId([1; 32]),
 			bolt12_invoice: None,
+			payment_nonce: None,
 		};
 
 		let decrypted_failure = process_onion_failure(&ctx_full, &logger, &htlc_source, packet);

--- a/lightning/src/ln/outbound_payment.rs
+++ b/lightning/src/ln/outbound_payment.rs
@@ -933,7 +933,7 @@ where
 		IH: Fn() -> InFlightHtlcs,
 		SP: Fn(SendAlongPathArgs) -> Result<(), APIError>,
 	{
-		let payment_hash = PaymentHash((*invoice.payment_hash()).to_byte_array());
+		let payment_hash = invoice.payment_hash();
 
 		let amount = match (invoice.amount_milli_satoshis(), amount_msats) {
 			(Some(amt), None) | (None, Some(amt)) => amt,

--- a/lightning/src/ln/outbound_payment.rs
+++ b/lightning/src/ln/outbound_payment.rs
@@ -124,6 +124,12 @@ pub(crate) enum PendingOutboundPayment {
 		// Storing the BOLT 12 invoice here to allow Proof of Payment after
 		// the payment is made.
 		bolt12_invoice: Option<PaidBolt12Invoice>,
+		/// The [`Nonce`] used when the BOLT 12 [`InvoiceRequest`] was created. Stored here so
+		/// retried paths can include the nonce in [`HTLCSource::OutboundRoute`] for payer proof
+		/// construction after payment success.
+		///
+		/// [`InvoiceRequest`]: crate::offers::invoice_request::InvoiceRequest
+		payment_nonce: Option<Nonce>,
 		custom_tlvs: Vec<(u64, Vec<u8>)>,
 		pending_amt_msat: u64,
 		/// Used to track the fee paid. Present iff the payment was serialized on 0.0.103+.
@@ -176,6 +182,13 @@ impl PendingOutboundPayment {
 	fn bolt12_invoice(&self) -> Option<&PaidBolt12Invoice> {
 		match self {
 			PendingOutboundPayment::Retryable { bolt12_invoice, .. } => bolt12_invoice.as_ref(),
+			_ => None,
+		}
+	}
+
+	fn payment_nonce(&self) -> Option<&Nonce> {
+		match self {
+			PendingOutboundPayment::Retryable { payment_nonce, .. } => payment_nonce.as_ref(),
 			_ => None,
 		}
 	}
@@ -833,6 +846,7 @@ pub(super) struct SendAlongPathArgs<'a> {
 	pub keysend_preimage: &'a Option<PaymentPreimage>,
 	pub invoice_request: Option<&'a InvoiceRequest>,
 	pub bolt12_invoice: Option<&'a PaidBolt12Invoice>,
+	pub payment_nonce: Option<&'a Nonce>,
 	pub session_priv_bytes: [u8; 32],
 	pub hold_htlc_at_next_hop: bool,
 }
@@ -965,7 +979,7 @@ where
 	pub(super) fn send_payment_for_bolt12_invoice<
 		R: Deref, ES: Deref, NS: Deref, NL: Deref, IH, SP
 	>(
-		&self, invoice: &Bolt12Invoice, payment_id: PaymentId, router: &R,
+		&self, invoice: &Bolt12Invoice, payment_id: PaymentId, payment_nonce: Option<Nonce>, router: &R,
 		first_hops: Vec<ChannelDetails>, features: Bolt12InvoiceFeatures, inflight_htlcs: IH,
 		entropy_source: &ES, node_signer: &NS, node_id_lookup: &NL,
 		secp_ctx: &Secp256k1<secp256k1::All>, best_block_height: u32,
@@ -1000,7 +1014,7 @@ where
 		}
 		let invoice = PaidBolt12Invoice::Bolt12Invoice(invoice.clone());
 		self.send_payment_for_bolt12_invoice_internal(
-			payment_id, payment_hash, None, None, invoice, route_params, retry_strategy, false, router,
+			payment_id, payment_hash, None, None, invoice, payment_nonce, route_params, retry_strategy, false, router,
 			first_hops, inflight_htlcs, entropy_source, node_signer, node_id_lookup, secp_ctx,
 			best_block_height, pending_events, send_payment_along_path
 		)
@@ -1012,7 +1026,7 @@ where
 	>(
 		&self, payment_id: PaymentId, payment_hash: PaymentHash,
 		keysend_preimage: Option<PaymentPreimage>, invoice_request: Option<&InvoiceRequest>,
-		bolt12_invoice: PaidBolt12Invoice,
+		bolt12_invoice: PaidBolt12Invoice, payment_nonce: Option<Nonce>,
 		mut route_params: RouteParameters, retry_strategy: Retry, hold_htlcs_at_next_hop: bool, router: &R,
 		first_hops: Vec<ChannelDetails>, inflight_htlcs: IH, entropy_source: &ES, node_signer: &NS,
 		node_id_lookup: &NL, secp_ctx: &Secp256k1<secp256k1::All>, best_block_height: u32,
@@ -1073,7 +1087,8 @@ where
 			hash_map::Entry::Occupied(entry) => match entry.get() {
 				PendingOutboundPayment::InvoiceReceived { .. } => {
 					let (retryable_payment, onion_session_privs) = Self::create_pending_payment(
-						payment_hash, recipient_onion.clone(), keysend_preimage, None, Some(bolt12_invoice.clone()), &route,
+						payment_hash, recipient_onion.clone(), keysend_preimage, None, Some(bolt12_invoice.clone()),
+						payment_nonce, &route,
 						Some(retry_strategy), payment_params, entropy_source, best_block_height,
 					);
 					*entry.into_mut() = retryable_payment;
@@ -1084,7 +1099,8 @@ where
 						invoice_request
 					} else { unreachable!() };
 					let (retryable_payment, onion_session_privs) = Self::create_pending_payment(
-						payment_hash, recipient_onion.clone(), keysend_preimage, Some(invreq), Some(bolt12_invoice.clone()), &route,
+						payment_hash, recipient_onion.clone(), keysend_preimage, Some(invreq), Some(bolt12_invoice.clone()),
+						payment_nonce, &route,
 						Some(retry_strategy), payment_params, entropy_source, best_block_height
 					);
 					outbounds.insert(payment_id, retryable_payment);
@@ -1097,7 +1113,8 @@ where
 		core::mem::drop(outbounds);
 
 		let result = self.pay_route_internal(
-			&route, payment_hash, &recipient_onion, keysend_preimage, invoice_request, Some(&bolt12_invoice), payment_id,
+			&route, payment_hash, &recipient_onion, keysend_preimage, invoice_request, Some(&bolt12_invoice),
+			payment_nonce.as_ref(), payment_id,
 			Some(route_params.final_value_msat), &onion_session_privs, hold_htlcs_at_next_hop, node_signer,
 			best_block_height, &send_payment_along_path
 		);
@@ -1290,6 +1307,7 @@ where
 			Some(keysend_preimage),
 			Some(&invoice_request),
 			invoice,
+			None,
 			route_params,
 			retry_strategy,
 			hold_htlcs_at_next_hop,
@@ -1499,7 +1517,7 @@ where
 			})?;
 
 		let res = self.pay_route_internal(&route, payment_hash, &recipient_onion,
-			keysend_preimage, None, None, payment_id, None, &onion_session_privs, false, node_signer,
+			keysend_preimage, None, None, None, payment_id, None, &onion_session_privs, false, node_signer,
 			best_block_height, &send_payment_along_path);
 		log_info!(self.logger, "Sending payment with id {} and hash {} returned {:?}",
 			payment_id, payment_hash, res);
@@ -1578,7 +1596,7 @@ where
 				}
 			}
 		}
-		let (total_msat, recipient_onion, keysend_preimage, onion_session_privs, invoice_request, bolt12_invoice) = {
+		let (total_msat, recipient_onion, keysend_preimage, onion_session_privs, invoice_request, bolt12_invoice, payment_nonce) = {
 			let mut outbounds = self.pending_outbound_payments.lock().unwrap();
 			match outbounds.entry(payment_id) {
 				hash_map::Entry::Occupied(mut payment) => {
@@ -1621,8 +1639,9 @@ where
 
 							payment.get_mut().increment_attempts();
 							let bolt12_invoice = payment.get().bolt12_invoice();
+							let payment_nonce = payment.get().payment_nonce().copied();
 
-							(total_msat, recipient_onion, keysend_preimage, onion_session_privs, invoice_request, bolt12_invoice.cloned())
+							(total_msat, recipient_onion, keysend_preimage, onion_session_privs, invoice_request, bolt12_invoice.cloned(), payment_nonce)
 						},
 						PendingOutboundPayment::Legacy { .. } => {
 							log_error!(self.logger, "Unable to retry payments that were initially sent on LDK versions prior to 0.0.102");
@@ -1662,7 +1681,8 @@ where
 			}
 		};
 		let res = self.pay_route_internal(&route, payment_hash, &recipient_onion, keysend_preimage,
-			invoice_request.as_ref(), bolt12_invoice.as_ref(), payment_id, Some(total_msat),
+			invoice_request.as_ref(), bolt12_invoice.as_ref(), payment_nonce.as_ref(),
+			payment_id, Some(total_msat),
 			&onion_session_privs, false, node_signer, best_block_height, &send_payment_along_path);
 		log_info!(self.logger, "Result retrying payment id {}: {:?}", &payment_id, res);
 		if let Err(e) = res {
@@ -1823,7 +1843,7 @@ where
 
 		let recipient_onion_fields = RecipientOnionFields::spontaneous_empty();
 		match self.pay_route_internal(&route, payment_hash, &recipient_onion_fields,
-			None, None, None, payment_id, None, &onion_session_privs, false, node_signer,
+			None, None, None, None, payment_id, None, &onion_session_privs, false, node_signer,
 			best_block_height, &send_payment_along_path
 		) {
 			Ok(()) => Ok((payment_hash, payment_id)),
@@ -1886,7 +1906,7 @@ where
 			hash_map::Entry::Occupied(_) => Err(PaymentSendFailure::DuplicatePayment),
 			hash_map::Entry::Vacant(entry) => {
 				let (payment, onion_session_privs) = Self::create_pending_payment(
-					payment_hash, recipient_onion, keysend_preimage, None, bolt12_invoice, route, retry_strategy,
+					payment_hash, recipient_onion, keysend_preimage, None, bolt12_invoice, None, route, retry_strategy,
 					payment_params, entropy_source, best_block_height
 				);
 				entry.insert(payment);
@@ -1899,7 +1919,8 @@ where
 	fn create_pending_payment<ES: Deref>(
 		payment_hash: PaymentHash, recipient_onion: RecipientOnionFields,
 		keysend_preimage: Option<PaymentPreimage>, invoice_request: Option<InvoiceRequest>,
-		bolt12_invoice: Option<PaidBolt12Invoice>, route: &Route, retry_strategy: Option<Retry>,
+		bolt12_invoice: Option<PaidBolt12Invoice>, payment_nonce: Option<Nonce>,
+		route: &Route, retry_strategy: Option<Retry>,
 		payment_params: Option<PaymentParameters>, entropy_source: &ES, best_block_height: u32
 	) -> (PendingOutboundPayment, Vec<[u8; 32]>)
 	where
@@ -1923,6 +1944,7 @@ where
 			keysend_preimage,
 			invoice_request,
 			bolt12_invoice,
+			payment_nonce,
 			custom_tlvs: recipient_onion.custom_tlvs,
 			starting_block_height: best_block_height,
 			total_msat: route.get_total_amount(),
@@ -2071,6 +2093,7 @@ where
 	fn pay_route_internal<NS: Deref, F>(
 		&self, route: &Route, payment_hash: PaymentHash, recipient_onion: &RecipientOnionFields,
 		keysend_preimage: Option<PaymentPreimage>, invoice_request: Option<&InvoiceRequest>, bolt12_invoice: Option<&PaidBolt12Invoice>,
+		payment_nonce: Option<&Nonce>,
 		payment_id: PaymentId, recv_value_msat: Option<u64>, onion_session_privs: &Vec<[u8; 32]>,
 		hold_htlcs_at_next_hop: bool, node_signer: &NS, best_block_height: u32, send_payment_along_path: &F
 	) -> Result<(), PaymentSendFailure>
@@ -2126,7 +2149,7 @@ where
 			let path_res = send_payment_along_path(SendAlongPathArgs {
 				path: &path, payment_hash: &payment_hash, recipient_onion, total_value,
 				cur_height, payment_id, keysend_preimage: &keysend_preimage, invoice_request,
-				bolt12_invoice, hold_htlc_at_next_hop: hold_htlcs_at_next_hop,
+				bolt12_invoice, payment_nonce, hold_htlc_at_next_hop: hold_htlcs_at_next_hop,
 				session_priv_bytes: *session_priv_bytes
 			});
 			results.push(path_res);
@@ -2194,7 +2217,7 @@ where
 		F: Fn(SendAlongPathArgs) -> Result<(), APIError>,
 	{
 		self.pay_route_internal(route, payment_hash, &recipient_onion,
-			keysend_preimage, None, None, payment_id, recv_value_msat, &onion_session_privs,
+			keysend_preimage, None, None, None, payment_id, recv_value_msat, &onion_session_privs,
 			false, node_signer, best_block_height, &send_payment_along_path)
 			.map_err(|e| { self.remove_outbound_if_all_failed(payment_id, &e); e })
 	}
@@ -2218,6 +2241,7 @@ where
 	#[rustfmt::skip]
 	pub(super) fn claim_htlc(
 		&self, payment_id: PaymentId, payment_preimage: PaymentPreimage, bolt12_invoice: Option<PaidBolt12Invoice>,
+		payment_nonce: Option<Nonce>,
 		session_priv: SecretKey, path: Path, from_onchain: bool, ev_completion_action: &mut Option<EventCompletionAction>,
 		pending_events: &Mutex<VecDeque<(events::Event, Option<EventCompletionAction>)>>,
 	) {
@@ -2238,6 +2262,7 @@ where
 					amount_msat,
 					fee_paid_msat,
 					bolt12_invoice: bolt12_invoice,
+					payment_nonce,
 				}, ev_completion_action.take()));
 				payment.get_mut().mark_fulfilled();
 			}
@@ -2638,6 +2663,7 @@ where
 					keysend_preimage: None, // only used for retries, and we'll never retry on startup
 					invoice_request: None, // only used for retries, and we'll never retry on startup
 					bolt12_invoice: None, // only used for retries, and we'll never retry on startup!
+					payment_nonce: None, // only used for retries, and we'll never retry on startup
 					custom_tlvs: Vec::new(), // only used for retries, and we'll never retry on startup
 					pending_amt_msat: path_amt,
 					pending_fee_msat: Some(path_fee),
@@ -2726,6 +2752,7 @@ impl_writeable_tlv_based_enum_upgradable!(PendingOutboundPayment,
 		(11, remaining_max_total_routing_fee_msat, option),
 		(13, invoice_request, option),
 		(15, bolt12_invoice, option),
+		(17, payment_nonce, option),
 		(not_written, retry_strategy, (static_value, None)),
 		(not_written, attempts, (static_value, PaymentAttempts::new())),
 	},
@@ -3212,7 +3239,7 @@ mod tests {
 
 		assert_eq!(
 			outbound_payments.send_payment_for_bolt12_invoice(
-				&invoice, payment_id, &&router, vec![], Bolt12InvoiceFeatures::empty(),
+				&invoice, payment_id, None, &&router, vec![], Bolt12InvoiceFeatures::empty(),
 				|| InFlightHtlcs::new(), &&keys_manager, &&keys_manager, &EmptyNodeIdLookUp {},
 				&secp_ctx, 0, &pending_events, |_| panic!()
 			),
@@ -3275,7 +3302,7 @@ mod tests {
 
 		assert_eq!(
 			outbound_payments.send_payment_for_bolt12_invoice(
-				&invoice, payment_id, &&router, vec![], Bolt12InvoiceFeatures::empty(),
+				&invoice, payment_id, None, &&router, vec![], Bolt12InvoiceFeatures::empty(),
 				|| InFlightHtlcs::new(), &&keys_manager, &&keys_manager, &EmptyNodeIdLookUp {},
 				&secp_ctx, 0, &pending_events, |_| panic!()
 			),
@@ -3351,7 +3378,7 @@ mod tests {
 		assert!(!outbound_payments.has_pending_payments());
 		assert_eq!(
 			outbound_payments.send_payment_for_bolt12_invoice(
-				&invoice, payment_id, &&router, vec![], Bolt12InvoiceFeatures::empty(),
+				&invoice, payment_id, None, &&router, vec![], Bolt12InvoiceFeatures::empty(),
 				|| InFlightHtlcs::new(), &&keys_manager, &&keys_manager, &EmptyNodeIdLookUp {},
 				&secp_ctx, 0, &pending_events, |_| panic!()
 			),
@@ -3371,7 +3398,7 @@ mod tests {
 
 		assert_eq!(
 			outbound_payments.send_payment_for_bolt12_invoice(
-				&invoice, payment_id, &&router, vec![], Bolt12InvoiceFeatures::empty(),
+				&invoice, payment_id, None, &&router, vec![], Bolt12InvoiceFeatures::empty(),
 				|| InFlightHtlcs::new(), &&keys_manager, &&keys_manager, &EmptyNodeIdLookUp {},
 				&secp_ctx, 0, &pending_events, |_| Ok(())
 			),
@@ -3382,7 +3409,7 @@ mod tests {
 
 		assert_eq!(
 			outbound_payments.send_payment_for_bolt12_invoice(
-				&invoice, payment_id, &&router, vec![], Bolt12InvoiceFeatures::empty(),
+				&invoice, payment_id, None, &&router, vec![], Bolt12InvoiceFeatures::empty(),
 				|| InFlightHtlcs::new(), &&keys_manager, &&keys_manager, &EmptyNodeIdLookUp {},
 				&secp_ctx, 0, &pending_events, |_| panic!()
 			),

--- a/lightning/src/ln/payment_tests.rs
+++ b/lightning/src/ln/payment_tests.rs
@@ -5103,6 +5103,7 @@ fn peel_payment_onion_custom_tlvs() {
 		onion_routing_packet,
 		blinding_point: None,
 		hold_htlc: None,
+		accountable: None,
 	};
 	let peeled_onion = crate::ln::onion_payment::peel_payment_onion(
 		&update_add,

--- a/lightning/src/offers/flow.rs
+++ b/lightning/src/offers/flow.rs
@@ -1319,6 +1319,7 @@ where
 			num_dummy_hops,
 			self.receive_auth_key,
 			context,
+			false,
 			&*entropy,
 			&self.secp_ctx,
 		)

--- a/lightning/src/offers/flow.rs
+++ b/lightning/src/offers/flow.rs
@@ -52,7 +52,7 @@ use crate::onion_message::async_payments::{
 	StaticInvoicePersisted,
 };
 use crate::onion_message::messenger::{
-	Destination, MessageRouter, MessageSendInstructions, Responder, PADDED_PATH_LENGTH,
+	Destination, MessageRouter, MessageSendInstructions, Responder, DUMMY_HOPS_PATH_LENGTH,
 };
 use crate::onion_message::offers::OffersMessage;
 use crate::onion_message::packet::OnionMessageContents;
@@ -1312,7 +1312,7 @@ where
 			prev_outbound_scid_alias,
 			htlc_id,
 		});
-		let num_dummy_hops = PADDED_PATH_LENGTH.saturating_sub(1);
+		let num_dummy_hops = DUMMY_HOPS_PATH_LENGTH.saturating_sub(1);
 		BlindedMessagePath::new_with_dummy_hops(
 			&[],
 			self.get_our_node_id(),

--- a/lightning/src/offers/flow.rs
+++ b/lightning/src/offers/flow.rs
@@ -495,11 +495,12 @@ where
 		Ok(InvreqResponseInstructions::SendInvoice(invoice_request))
 	}
 
-	/// Verifies a [`Bolt12Invoice`] using the provided [`OffersContext`] or the invoice's payer metadata,
-	/// returning the corresponding [`PaymentId`] if successful.
+	/// Verifies a [`Bolt12Invoice`] using the provided [`OffersContext`] or the invoice's payer
+	/// metadata, returning the corresponding [`PaymentId`] if successful.
 	///
-	/// - If an [`OffersContext::OutboundPayment`] with a `nonce` is provided, verification is performed
-	///   using this to form the payer metadata.
+	/// - If an [`OffersContext::OutboundPaymentForOffer`] or
+	///   [`OffersContext::OutboundPaymentForRefund`] with a `nonce` is provided, verification is
+	///   performed using this to form the payer metadata.
 	/// - If no context is provided and the invoice corresponds to a [`Refund`] without blinded paths,
 	///   verification is performed using the [`Bolt12Invoice::payer_metadata`].
 	/// - If neither condition is met, verification fails.
@@ -513,8 +514,19 @@ where
 			None if invoice.is_for_refund_without_paths() => {
 				invoice.verify_using_metadata(expanded_key, secp_ctx)
 			},
-			Some(&OffersContext::OutboundPayment { payment_id, nonce, .. }) => {
-				invoice.verify_using_payer_data(payment_id, nonce, expanded_key, secp_ctx)
+			Some(&OffersContext::OutboundPaymentForOffer { payment_id, nonce, .. }) => {
+				if invoice.is_for_offer() {
+					invoice.verify_using_payer_data(payment_id, nonce, expanded_key, secp_ctx)
+				} else {
+					Err(())
+				}
+			},
+			Some(&OffersContext::OutboundPaymentForRefund { payment_id, nonce, .. }) => {
+				if invoice.is_for_refund() {
+					invoice.verify_using_payer_data(payment_id, nonce, expanded_key, secp_ctx)
+				} else {
+					Err(())
+				}
 			},
 			_ => Err(()),
 		}
@@ -680,7 +692,8 @@ where
 		let secp_ctx = &self.secp_ctx;
 
 		let nonce = Nonce::from_entropy_source(entropy);
-		let context = MessageContext::Offers(OffersContext::OutboundPayment { payment_id, nonce });
+		let context =
+			MessageContext::Offers(OffersContext::OutboundPaymentForRefund { payment_id, nonce });
 
 		// Create the base builder with common properties
 		let mut builder = RefundBuilder::deriving_signing_pubkey(
@@ -1116,7 +1129,8 @@ where
 		&self, invoice_request: InvoiceRequest, payment_id: PaymentId, nonce: Nonce,
 		peers: Vec<MessageForwardNode>,
 	) -> Result<(), Bolt12SemanticError> {
-		let context = MessageContext::Offers(OffersContext::OutboundPayment { payment_id, nonce });
+		let context =
+			MessageContext::Offers(OffersContext::OutboundPaymentForOffer { payment_id, nonce });
 		let reply_paths = self
 			.create_blinded_paths(peers, context)
 			.map_err(|_| Bolt12SemanticError::MissingPaths)?;

--- a/lightning/src/offers/invoice.rs
+++ b/lightning/src/offers/invoice.rs
@@ -778,6 +778,19 @@ struct InvoiceFields {
 }
 
 macro_rules! invoice_accessors { ($self: ident, $contents: expr) => {
+	/// Whether the invoice was created in response to a [`Refund`].
+	pub fn is_for_refund(&$self) -> bool {
+		$contents.is_for_refund()
+	}
+
+	/// Whether the invoice was created in response to an [`InvoiceRequest`] created from an
+	/// [`Offer`].
+	///
+	/// [`Offer`]: crate::offers::offer::Offer
+	pub fn is_for_offer(&$self) -> bool {
+		$contents.is_for_offer()
+	}
+
 	/// The chains that may be used when paying a requested invoice.
 	///
 	/// From [`Offer::chains`]; `None` if the invoice was created in response to a [`Refund`].
@@ -1090,6 +1103,20 @@ impl InvoiceContents {
 			InvoiceContents::ForRefund { refund, .. } => {
 				refund.is_expired_no_std(duration_since_epoch)
 			},
+		}
+	}
+
+	fn is_for_refund(&self) -> bool {
+		match self {
+			InvoiceContents::ForRefund { .. } => true,
+			InvoiceContents::ForOffer { .. } => false,
+		}
+	}
+
+	fn is_for_offer(&self) -> bool {
+		match self {
+			InvoiceContents::ForRefund { .. } => false,
+			InvoiceContents::ForOffer { .. } => true,
 		}
 	}
 

--- a/lightning/src/onion_message/messenger.rs
+++ b/lightning/src/onion_message/messenger.rs
@@ -772,6 +772,9 @@ where
 /// [`DefaultMessageRouter`] for deciding when to add additional dummy hops to the generated blinded
 /// paths.
 ///
+/// This may be useful in cases where you want a long-lived blinded path and anticipate channel(s)
+/// may close, but connections to specific peers will remain stable.
+///
 /// This message router can only route to a directly connected [`Destination`].
 ///
 /// # Privacy

--- a/lightning/src/onion_message/messenger.rs
+++ b/lightning/src/onion_message/messenger.rs
@@ -524,9 +524,11 @@ pub trait MessageRouter {
 
 /// A [`MessageRouter`] that can only route to a directly connected [`Destination`].
 ///
-/// [`DefaultMessageRouter`] constructs compact [`BlindedMessagePath`]s on a best-effort basis.
-/// That is, if appropriate SCID information is available for the intermediate peers, it will
-/// default to creating compact paths.
+/// [`DefaultMessageRouter`] tries to construct compact or private [`BlindedMessagePath`]s based on
+/// the [`MessageContext`] given to [`MessageRouter::create_blinded_paths`]. That is, if the
+/// provided context implies the path may be used in a BOLT 12 object which might appear in a QR
+/// code, it reduces the amount of padding and dummy hops and prefers building compact paths when
+/// short channel IDs (SCIDs) are available for intermediate peers.
 ///
 /// # Compact Blinded Paths
 ///
@@ -545,7 +547,8 @@ pub trait MessageRouter {
 /// Creating [`BlindedMessagePath`]s may affect privacy since, if a suitable path cannot be found,
 /// it will create a one-hop path using the recipient as the introduction node if it is an announced
 /// node. Otherwise, there is no way to find a path to the introduction node in order to send a
-/// message, and thus an `Err` is returned.
+/// message, and thus an `Err` is returned. The impact of this may be somewhat muted when
+/// additional dummy hops are added to the blinded path, but this protection is not complete.
 pub struct DefaultMessageRouter<G: Deref<Target = NetworkGraph<L>>, L: Deref, ES: Deref>
 where
 	L::Target: Logger,
@@ -555,13 +558,16 @@ where
 	entropy_source: ES,
 }
 
-// Target total length (in hops) for non-compact blinded paths.
-// We pad with dummy hops until the path reaches this length,
-// obscuring the recipient's true position.
+// Target total length (in hops) for blinded paths used outside of QR codes.
 //
-// Compact paths are optimized for minimal size, so we avoid
-// adding dummy hops to them.
-pub(crate) const PADDED_PATH_LENGTH: usize = 4;
+// We add dummy hops until the path reaches this length (including the recipient).
+pub(crate) const DUMMY_HOPS_PATH_LENGTH: usize = 4;
+
+// Target total length (in hops) for blinded paths included in objects which may appear in a QR
+// code.
+//
+// We add dummy hops until the path reaches this length (including the recipient).
+pub(crate) const QR_CODED_DUMMY_HOPS_PATH_LENGTH: usize = 2;
 
 impl<G: Deref<Target = NetworkGraph<L>>, L: Deref, ES: Deref> DefaultMessageRouter<G, L, ES>
 where
@@ -574,12 +580,12 @@ where
 	}
 
 	pub(crate) fn create_blinded_paths_from_iter<
-		I: ExactSizeIterator<Item = MessageForwardNode>,
+		I: ExactSizeIterator<Item = MessageForwardNode> + Clone,
 		T: secp256k1::Signing + secp256k1::Verification,
 	>(
 		network_graph: &G, recipient: PublicKey, local_node_receive_key: ReceiveAuthKey,
 		context: MessageContext, peers: I, entropy_source: &ES, secp_ctx: &Secp256k1<T>,
-		compact_paths: bool,
+		never_compact_path: bool,
 	) -> Result<Vec<BlindedMessagePath>, ()> {
 		// Limit the number of blinded paths that are computed.
 		const MAX_PATHS: usize = 3;
@@ -591,6 +597,33 @@ where
 		let network_graph = network_graph.deref().read_only();
 		let is_recipient_announced =
 			network_graph.nodes().contains_key(&NodeId::from_pubkey(&recipient));
+
+		let (mut compact_paths, dummy_hopd_path_len) = match &context {
+			MessageContext::Offers(OffersContext::InvoiceRequest { .. })
+			| MessageContext::Offers(OffersContext::OutboundPaymentForRefund { .. }) => {
+				// When embedding blinded paths within BOLT 12 objects which are generally embedded
+				// in QR codes, we sadly need to be conservative about size, especially if the QR
+				// code ultimately also includes an on-chain address.
+				(true, QR_CODED_DUMMY_HOPS_PATH_LENGTH)
+			},
+			MessageContext::Offers(OffersContext::StaticInvoiceRequested { .. }) => {
+				// Async Payments aggressively embeds the entire `InvoiceRequest` in the payment
+				// onion. In a future version it should likely move to embedding only the
+				// `InvoiceRequest`-specific fields instead, but until then we have to be
+				// incredibly strict in the size of the blinded path we include in a static payment
+				// `Offer`.
+				(true, 0)
+			},
+			_ => {
+				// If there's no need to be small, add additional dummy hops and never use
+				// SCID-based next-hops as they carry additional expiry risk.
+				(false, DUMMY_HOPS_PATH_LENGTH)
+			},
+		};
+
+		if never_compact_path {
+			compact_paths = false;
+		}
 
 		let has_one_peer = peers.len() == 1;
 		let mut peer_info = peers
@@ -619,12 +652,8 @@ where
 		});
 
 		let build_path = |intermediate_hops: &[MessageForwardNode]| {
-			let dummy_hops_count = if compact_paths {
-				0
-			} else {
-				// Add one for the final recipient TLV
-				PADDED_PATH_LENGTH.saturating_sub(intermediate_hops.len() + 1)
-			};
+			// Calculate the dummy hops given the total hop count target (including the recipient).
+			let dummy_hops_count = dummy_hopd_path_len.saturating_sub(intermediate_hops.len() + 1);
 
 			BlindedMessagePath::new_with_dummy_hops(
 				intermediate_hops,
@@ -649,12 +678,6 @@ where
 			} else {
 				return Err(());
 			}
-		}
-
-		// Sanity check: Ones the paths are created for the non-compact case, ensure
-		// each of them are of the length `PADDED_PATH_LENGTH`.
-		if !compact_paths {
-			debug_assert!(paths.iter().all(|path| path.blinded_hops().len() == PADDED_PATH_LENGTH));
 		}
 
 		if compact_paths {
@@ -740,13 +763,15 @@ where
 			peers.into_iter(),
 			&self.entropy_source,
 			secp_ctx,
-			true,
+			false,
 		)
 	}
 }
 
 /// This message router is similar to [`DefaultMessageRouter`], but it always creates
-/// full-length blinded paths, using the peer's [`NodeId`].
+/// non-compact blinded paths, using the peer's [`NodeId`]. It uses the same heuristics as
+/// [`DefaultMessageRouter`] for deciding when to add additional dummy hops to the generated blinded
+/// paths.
 ///
 /// This message router can only route to a directly connected [`Destination`].
 ///
@@ -755,7 +780,8 @@ where
 /// Creating [`BlindedMessagePath`]s may affect privacy since, if a suitable path cannot be found,
 /// it will create a one-hop path using the recipient as the introduction node if it is an announced
 /// node. Otherwise, there is no way to find a path to the introduction node in order to send a
-/// message, and thus an `Err` is returned.
+/// message, and thus an `Err` is returned. The impact of this may be somewhat muted when
+/// additional dummy hops are added to the blinded path, but this protection is not complete.
 pub struct NodeIdMessageRouter<G: Deref<Target = NetworkGraph<L>>, L: Deref, ES: Deref>
 where
 	L::Target: Logger,
@@ -790,8 +816,11 @@ where
 
 	fn create_blinded_paths<T: secp256k1::Signing + secp256k1::Verification>(
 		&self, recipient: PublicKey, local_node_receive_key: ReceiveAuthKey,
-		context: MessageContext, peers: Vec<MessageForwardNode>, secp_ctx: &Secp256k1<T>,
+		context: MessageContext, mut peers: Vec<MessageForwardNode>, secp_ctx: &Secp256k1<T>,
 	) -> Result<Vec<BlindedMessagePath>, ()> {
+		for peer in peers.iter_mut() {
+			peer.short_channel_id = None;
+		}
 		DefaultMessageRouter::create_blinded_paths_from_iter(
 			&self.network_graph,
 			recipient,
@@ -800,7 +829,7 @@ where
 			peers.into_iter(),
 			&self.entropy_source,
 			secp_ctx,
-			false,
+			true,
 		)
 	}
 }

--- a/lightning/src/routing/gossip.rs
+++ b/lightning/src/routing/gossip.rs
@@ -43,6 +43,7 @@ use crate::util::indexed_map::{
 use crate::util::logger::{Level, Logger};
 use crate::util::scid_utils::{block_from_scid, scid_from_parts, MAX_SCID_BLOCK};
 use crate::util::ser::{MaybeReadable, Readable, ReadableArgs, RequiredWrapper, Writeable, Writer};
+use crate::util::wakers::Future;
 
 use crate::io;
 use crate::io_extras::{copy, sink};
@@ -365,6 +366,17 @@ where
 	/// This is not exported to bindings users as bindings don't support a reference-to-a-reference yet
 	pub fn network_graph(&self) -> &G {
 		&self.network_graph
+	}
+
+	/// Gets a [`Future`] which will resolve the next time an async validation of gossip data
+	/// completes.
+	///
+	/// If the [`UtxoLookup`] provided in [`P2PGossipSync::new`] does not return
+	/// [`UtxoResult::Async`] values, the returned [`Future`] will never resolve
+	///
+	/// [`UtxoResult::Async`]: crate::routing::utxo::UtxoResult::Async
+	pub fn validation_completion_future(&self) -> Future {
+		self.network_graph.pending_checks.completion_notifier.get_future()
 	}
 
 	/// Returns true when a full routing table sync should be performed with a peer.

--- a/lightning/src/routing/gossip.rs
+++ b/lightning/src/routing/gossip.rs
@@ -1772,13 +1772,15 @@ where
 	}
 }
 
-// In Jan, 2025 there were about 49K channels.
-// We over-allocate by a bit because 20% more is better than the double we get if we're slightly
-// too low
-const CHAN_COUNT_ESTIMATE: usize = 60_000;
-// In Jan, 2025 there were about 15K nodes
-// We over-allocate by a bit because 33% more is better than the double we get if we're slightly
-// too low
+/// In Jan, 2026 there were about 54K channels.
+///
+/// We over-allocate by a bit because ~15% more is better than the double we get if we're slightly
+/// too low.
+const CHAN_COUNT_ESTIMATE: usize = 63_000;
+/// In Jan, 2026 there were about 17K nodes
+///
+/// We over-allocate by a bit because 15% more is better than the double we get if we're slightly
+/// too low.
 const NODE_COUNT_ESTIMATE: usize = 20_000;
 
 impl<L: Deref> NetworkGraph<L>

--- a/lightning/src/routing/gossip.rs
+++ b/lightning/src/routing/gossip.rs
@@ -1802,12 +1802,18 @@ where
 {
 	/// Creates a new, empty, network graph.
 	pub fn new(network: Network, logger: L) -> NetworkGraph<L> {
+		let (node_map_cap, chan_map_cap) = if matches!(network, Network::Bitcoin) {
+			(NODE_COUNT_ESTIMATE, CHAN_COUNT_ESTIMATE)
+		} else {
+			(0, 0)
+		};
+
 		Self {
 			secp_ctx: Secp256k1::verification_only(),
 			chain_hash: ChainHash::using_genesis_block(network),
 			logger,
-			channels: RwLock::new(IndexedMap::with_capacity(CHAN_COUNT_ESTIMATE)),
-			nodes: RwLock::new(IndexedMap::with_capacity(NODE_COUNT_ESTIMATE)),
+			channels: RwLock::new(IndexedMap::with_capacity(chan_map_cap)),
+			nodes: RwLock::new(IndexedMap::with_capacity(node_map_cap)),
 			next_node_counter: AtomicUsize::new(0),
 			removed_node_counters: Mutex::new(Vec::new()),
 			last_rapid_gossip_sync_timestamp: Mutex::new(None),

--- a/lightning/src/routing/utxo.rs
+++ b/lightning/src/routing/utxo.rs
@@ -21,7 +21,7 @@ use bitcoin::hex::DisplayHex;
 
 use crate::ln::chan_utils::make_funding_redeemscript_from_slices;
 use crate::ln::msgs::{self, ErrorAction, LightningError, MessageSendEvent};
-use crate::routing::gossip::{NetworkGraph, NodeId, P2PGossipSync};
+use crate::routing::gossip::{NetworkGraph, NodeId};
 use crate::util::logger::{Level, Logger};
 use crate::util::wakers::Notifier;
 
@@ -157,176 +157,17 @@ impl UtxoFuture {
 		}
 	}
 
-	/// Resolves this future against the given `graph` and with the given `result`.
-	///
-	/// This is identical to calling [`UtxoFuture::resolve`] with a dummy `gossip`, disabling
-	/// forwarding the validated gossip message onwards to peers.
-	///
-	/// Because this may cause the [`NetworkGraph`]'s [`processing_queue_high`] to flip, in order
-	/// to allow us to interact with peers again, you should call [`PeerManager::process_events`]
-	/// after this.
-	///
-	/// [`processing_queue_high`]: crate::ln::msgs::RoutingMessageHandler::processing_queue_high
-	/// [`PeerManager::process_events`]: crate::ln::peer_handler::PeerManager::process_events
-	pub fn resolve_without_forwarding<L: Deref>(
-		&self, graph: &NetworkGraph<L>, result: Result<TxOut, UtxoLookupError>,
-	) where
-		L::Target: Logger,
-	{
-		self.do_resolve(graph, result);
-	}
-
-	/// Resolves this future against the given `graph` and with the given `result`.
-	///
-	/// The given `gossip` is used to broadcast any validated messages onwards to all peers which
-	/// have available buffer space.
-	///
-	/// Because this may cause the [`NetworkGraph`]'s [`processing_queue_high`] to flip, in order
-	/// to allow us to interact with peers again, you should call [`PeerManager::process_events`]
-	/// after this.
-	///
-	/// [`processing_queue_high`]: crate::ln::msgs::RoutingMessageHandler::processing_queue_high
-	/// [`PeerManager::process_events`]: crate::ln::peer_handler::PeerManager::process_events
-	pub fn resolve<
-		L: Deref,
-		G: Deref<Target = NetworkGraph<L>>,
-		U: Deref,
-		GS: Deref<Target = P2PGossipSync<G, U, L>>,
-	>(
-		&self, graph: &NetworkGraph<L>, gossip: GS, result: Result<TxOut, UtxoLookupError>,
-	) where
-		L::Target: Logger,
-		U::Target: UtxoLookup,
-	{
-		let mut res = self.do_resolve(graph, result);
-		for msg_opt in res.iter_mut() {
-			if let Some(msg) = msg_opt.take() {
-				gossip.forward_gossip_msg(msg);
-			}
-		}
-	}
-
-	#[rustfmt::skip]
-	fn do_resolve<L: Deref>(&self, graph: &NetworkGraph<L>, result: Result<TxOut, UtxoLookupError>)
-	-> [Option<MessageSendEvent>; 5] where L::Target: Logger {
-		let (announcement, node_a, node_b, update_a, update_b) = {
-			let mut pending_checks = graph.pending_checks.internal.lock().unwrap();
-			let mut async_messages = self.state.lock().unwrap();
-			async_messages.notifier.notify();
-
-			if async_messages.channel_announce.is_none() {
-				// We raced returning to `check_channel_announcement` which hasn't updated
-				// `channel_announce` yet. That's okay, we can set the `complete` field which it will
-				// check once it gets control again.
-				async_messages.complete = Some(result);
-				return [None, None, None, None, None];
-			}
-
-			let announcement_msg = match async_messages.channel_announce.as_ref().unwrap() {
-				ChannelAnnouncement::Full(signed_msg) => &signed_msg.contents,
-				ChannelAnnouncement::Unsigned(msg) => &msg,
-			};
-
-			pending_checks.lookup_completed(announcement_msg, &Arc::downgrade(&self.state));
-
-			(async_messages.channel_announce.take().unwrap(),
-				async_messages.latest_node_announce_a.take(),
-				async_messages.latest_node_announce_b.take(),
-				async_messages.latest_channel_update_a.take(),
-				async_messages.latest_channel_update_b.take())
-		};
-
-		let mut res = [None, None, None, None, None];
-		let mut res_idx = 0;
-
-		// Now that we've updated our internal state, pass the pending messages back through the
-		// network graph with a different `UtxoLookup` which will resolve immediately.
-		// Note that we ignore errors as we don't disconnect peers anyway, so there's nothing to do
-		// with them.
-		let resolver = UtxoResolver(result);
-		let (node_id_1, node_id_2) = match &announcement {
-			ChannelAnnouncement::Full(signed_msg) => (signed_msg.contents.node_id_1, signed_msg.contents.node_id_2),
-			ChannelAnnouncement::Unsigned(msg) => (msg.node_id_1, msg.node_id_2),
-		};
-		match announcement {
-			ChannelAnnouncement::Full(signed_msg) => {
-				if graph.update_channel_from_announcement(&signed_msg, &Some(&resolver)).is_ok() {
-					res[res_idx] = Some(MessageSendEvent::BroadcastChannelAnnouncement {
-						msg: signed_msg, update_msg: None,
-					});
-					res_idx += 1;
-				}
-			},
-			ChannelAnnouncement::Unsigned(msg) => {
-				let _ = graph.update_channel_from_unsigned_announcement(&msg, &Some(&resolver));
-			},
-		}
-
-		for announce in core::iter::once(node_a).chain(core::iter::once(node_b)) {
-			match announce {
-				Some(NodeAnnouncement::Full(signed_msg)) => {
-					if graph.update_node_from_announcement(&signed_msg).is_ok() {
-						res[res_idx] = Some(MessageSendEvent::BroadcastNodeAnnouncement {
-							msg: signed_msg,
-						});
-						res_idx += 1;
-					}
-				},
-				Some(NodeAnnouncement::Unsigned(msg)) => {
-					let _ = graph.update_node_from_unsigned_announcement(&msg);
-				},
-				None => {},
-			}
-		}
-
-		for update in core::iter::once(update_a).chain(core::iter::once(update_b)) {
-			match update {
-				Some(ChannelUpdate::Full(signed_msg)) => {
-					if graph.update_channel(&signed_msg).is_ok() {
-						res[res_idx] = Some(MessageSendEvent::BroadcastChannelUpdate {
-							msg: signed_msg,
-							node_id_1,
-							node_id_2,
-						});
-						res_idx += 1;
-					}
-				},
-				Some(ChannelUpdate::Unsigned(msg)) => {
-					let _ = graph.update_channel_unsigned(&msg);
-				},
-				None => {},
-			}
-		}
-
-		res
+	/// Resolves this future with the given result.
+	pub fn resolve(&self, result: Result<TxOut, UtxoLookupError>) {
+		let mut state = self.state.lock().unwrap();
+		state.complete = Some(result);
+		state.notifier.notify();
 	}
 }
 
 struct PendingChecksContext {
 	channels: HashMap<u64, Weak<Mutex<UtxoMessages>>>,
 	nodes: HashMap<NodeId, Vec<Weak<Mutex<UtxoMessages>>>>,
-}
-
-impl PendingChecksContext {
-	#[rustfmt::skip]
-	fn lookup_completed(&mut self,
-		msg: &msgs::UnsignedChannelAnnouncement, completed_state: &Weak<Mutex<UtxoMessages>>
-	) {
-		if let hash_map::Entry::Occupied(e) = self.channels.entry(msg.short_channel_id) {
-			if Weak::ptr_eq(e.get(), &completed_state) {
-				e.remove();
-			}
-		}
-
-		if let hash_map::Entry::Occupied(mut e) = self.nodes.entry(msg.node_id_1) {
-			e.get_mut().retain(|elem| !Weak::ptr_eq(&elem, &completed_state));
-			if e.get().is_empty() { e.remove(); }
-		}
-		if let hash_map::Entry::Occupied(mut e) = self.nodes.entry(msg.node_id_2) {
-			e.get_mut().retain(|elem| !Weak::ptr_eq(&elem, &completed_state));
-			if e.get().is_empty() { e.remove(); }
-		}
-	}
 }
 
 /// A set of messages which are pending UTXO lookups for processing.
@@ -597,6 +438,142 @@ impl PendingChecks {
 			false
 		}
 	}
+
+	fn resolve_single_future<L: Deref>(
+		&self, graph: &NetworkGraph<L>, entry: Arc<Mutex<UtxoMessages>>,
+		new_messages: &mut Vec<MessageSendEvent>,
+	) where
+		L::Target: Logger,
+	{
+		let (announcement, result, announce_a, announce_b, update_a, update_b);
+		{
+			let mut state = entry.lock().unwrap();
+			announcement = if let Some(announcement) = state.channel_announce.take() {
+				announcement
+			} else {
+				// We raced returning to `check_channel_announcement` which hasn't updated
+				// `channel_announce` yet. That's okay, we can set the `complete` field which it will
+				// check once it gets control again.
+				return;
+			};
+
+			result = if let Some(result) = state.complete.take() {
+				result
+			} else {
+				debug_assert!(false, "Future should have been resolved");
+				return;
+			};
+
+			announce_a = state.latest_node_announce_a.take();
+			announce_b = state.latest_node_announce_b.take();
+			update_a = state.latest_channel_update_a.take();
+			update_b = state.latest_channel_update_b.take();
+		}
+
+		// Now that we've updated our internal state, pass the pending messages back through the
+		// network graph with a different `UtxoLookup` which will resolve immediately.
+		// Note that we ignore errors as we don't disconnect peers anyway, so there's nothing to do
+		// with them.
+		let resolver = UtxoResolver(result);
+		let (node_id_1, node_id_2) = match &announcement {
+			ChannelAnnouncement::Full(signed_msg) => {
+				(signed_msg.contents.node_id_1, signed_msg.contents.node_id_2)
+			},
+			ChannelAnnouncement::Unsigned(msg) => (msg.node_id_1, msg.node_id_2),
+		};
+		match announcement {
+			ChannelAnnouncement::Full(signed_msg) => {
+				if graph.update_channel_from_announcement(&signed_msg, &Some(&resolver)).is_ok() {
+					new_messages.push(MessageSendEvent::BroadcastChannelAnnouncement {
+						msg: signed_msg,
+						update_msg: None,
+					});
+				}
+			},
+			ChannelAnnouncement::Unsigned(msg) => {
+				let _ = graph.update_channel_from_unsigned_announcement(&msg, &Some(&resolver));
+			},
+		}
+
+		for announce in [announce_a, announce_b] {
+			match announce {
+				Some(NodeAnnouncement::Full(signed_msg)) => {
+					if graph.update_node_from_announcement(&signed_msg).is_ok() {
+						new_messages
+							.push(MessageSendEvent::BroadcastNodeAnnouncement { msg: signed_msg });
+					}
+				},
+				Some(NodeAnnouncement::Unsigned(msg)) => {
+					let _ = graph.update_node_from_unsigned_announcement(&msg);
+				},
+				None => {},
+			}
+		}
+
+		for update in [update_a, update_b] {
+			match update {
+				Some(ChannelUpdate::Full(signed_msg)) => {
+					if graph.update_channel(&signed_msg).is_ok() {
+						new_messages.push(MessageSendEvent::BroadcastChannelUpdate {
+							msg: signed_msg,
+							node_id_1,
+							node_id_2,
+						});
+					}
+				},
+				Some(ChannelUpdate::Unsigned(msg)) => {
+					let _ = graph.update_channel_unsigned(&msg);
+				},
+				None => {},
+			}
+		}
+	}
+
+	pub(super) fn check_resolved_futures<L: Deref>(
+		&self, graph: &NetworkGraph<L>,
+	) -> Vec<MessageSendEvent>
+	where
+		L::Target: Logger,
+	{
+		let mut completed_states = Vec::new();
+		{
+			let mut lck = self.internal.lock().unwrap();
+			lck.channels.retain(|_, state| {
+				if let Some(state) = state.upgrade() {
+					if state.lock().unwrap().complete.is_some() {
+						completed_states.push(state);
+						false
+					} else {
+						true
+					}
+				} else {
+					// The UtxoFuture has been dropped, drop the pending-lookup state.
+					false
+				}
+			});
+			lck.nodes.retain(|_, lookups| {
+				lookups.retain(|state| {
+					if let Some(state) = state.upgrade() {
+						if state.lock().unwrap().complete.is_some() {
+							completed_states.push(state);
+							false
+						} else {
+							true
+						}
+					} else {
+						// The UtxoFuture has been dropped, drop the pending-lookup state.
+						false
+					}
+				});
+				!lookups.is_empty()
+			});
+		}
+		let mut res = Vec::with_capacity(completed_states.len() * 5);
+		for state in completed_states {
+			self.resolve_single_future(graph, state, &mut res);
+		}
+		res
+	}
 }
 
 #[cfg(test)]
@@ -654,9 +631,10 @@ mod tests {
 
 		let notifier = Arc::new(Notifier::new());
 		let future = UtxoFuture::new(Arc::clone(&notifier));
-		future.resolve_without_forwarding(&network_graph,
-			Ok(TxOut { value: Amount::from_sat(1_000_000), script_pubkey: good_script }));
+		future
+			.resolve(Ok(TxOut { value: Amount::from_sat(1_000_000), script_pubkey: good_script }));
 		assert!(notifier.notify_pending());
+		network_graph.pending_checks.check_resolved_futures(&network_graph);
 		*chain_source.utxo_ret.lock().unwrap() = UtxoResult::Async(future.clone());
 
 		network_graph.update_channel_from_announcement(&valid_announcement, &Some(&chain_source)).unwrap();
@@ -679,9 +657,9 @@ mod tests {
 			"Channel being checked async");
 		assert!(network_graph.read_only().channels().get(&valid_announcement.contents.short_channel_id).is_none());
 
-		future.resolve_without_forwarding(&network_graph,
-			Ok(TxOut { value: Amount::ZERO, script_pubkey: good_script }));
+		future.resolve(Ok(TxOut { value: Amount::ZERO, script_pubkey: good_script }));
 		assert!(notifier.notify_pending());
+		network_graph.pending_checks.check_resolved_futures(&network_graph);
 		network_graph.read_only().channels().get(&valid_announcement.contents.short_channel_id).unwrap();
 		network_graph.read_only().channels().get(&valid_announcement.contents.short_channel_id).unwrap();
 
@@ -710,9 +688,10 @@ mod tests {
 			"Channel being checked async");
 		assert!(network_graph.read_only().channels().get(&valid_announcement.contents.short_channel_id).is_none());
 
-		future.resolve_without_forwarding(&network_graph,
-			Ok(TxOut { value: Amount::from_sat(1_000_000), script_pubkey: bitcoin::ScriptBuf::new() }));
+		let value = Amount::from_sat(1_000_000);
+		future.resolve(Ok(TxOut { value, script_pubkey: bitcoin::ScriptBuf::new() }));
 		assert!(notifier.notify_pending());
+		network_graph.pending_checks.check_resolved_futures(&network_graph);
 		assert!(network_graph.read_only().channels().get(&valid_announcement.contents.short_channel_id).is_none());
 	}
 
@@ -731,8 +710,9 @@ mod tests {
 			"Channel being checked async");
 		assert!(network_graph.read_only().channels().get(&valid_announcement.contents.short_channel_id).is_none());
 
-		future.resolve_without_forwarding(&network_graph, Err(UtxoLookupError::UnknownTx));
+		future.resolve(Err(UtxoLookupError::UnknownTx));
 		assert!(notifier.notify_pending());
+		network_graph.pending_checks.check_resolved_futures(&network_graph);
 		assert!(network_graph.read_only().channels().get(&valid_announcement.contents.short_channel_id).is_none());
 	}
 
@@ -766,9 +746,10 @@ mod tests {
 			"Awaiting channel_announcement validation to accept channel_update");
 
 		assert!(!notifier.notify_pending());
-		future.resolve_without_forwarding(&network_graph,
-			Ok(TxOut { value: Amount::from_sat(1_000_000), script_pubkey: good_script }));
+		future
+			.resolve(Ok(TxOut { value: Amount::from_sat(1_000_000), script_pubkey: good_script }));
 		assert!(notifier.notify_pending());
+		network_graph.pending_checks.check_resolved_futures(&network_graph);
 
 		assert!(network_graph.read_only().channels()
 			.get(&valid_announcement.contents.short_channel_id).unwrap().one_to_two.is_some());
@@ -806,9 +787,9 @@ mod tests {
 			"Awaiting channel_announcement validation to accept channel_update");
 
 		assert!(!notifier.notify_pending());
-		future.resolve_without_forwarding(&network_graph,
-			Ok(TxOut { value: Amount::from_sat(1_000_000), script_pubkey: good_script }));
+		future.resolve(Ok(TxOut { value: Amount::from_sat(1_000_000), script_pubkey: good_script }));
 		assert!(notifier.notify_pending());
+		network_graph.pending_checks.check_resolved_futures(&network_graph);
 
 		assert_eq!(chan_update_a.contents.timestamp, chan_update_b.contents.timestamp);
 		let graph_lock = network_graph.read_only();
@@ -857,10 +838,11 @@ mod tests {
 		assert_eq!(chain_source.get_utxo_call_count.load(Ordering::Relaxed), 2);
 
 		// Still, if we resolve the original future, the original channel will be accepted.
-		future.resolve_without_forwarding(&network_graph,
-			Ok(TxOut { value: Amount::from_sat(1_000_000), script_pubkey: good_script }));
+		future
+			.resolve(Ok(TxOut { value: Amount::from_sat(1_000_000), script_pubkey: good_script }));
 		assert!(notifier_a.notify_pending());
 		assert!(!notifier_b.notify_pending());
+		network_graph.pending_checks.check_resolved_futures(&network_graph);
 		assert!(!network_graph.read_only().channels()
 			.get(&valid_announcement.contents.short_channel_id).unwrap()
 			.announcement_message.as_ref().unwrap()
@@ -896,8 +878,9 @@ mod tests {
 		assert!(network_graph.pending_checks.too_many_checks_pending());
 
 		// Once the future completes the "too many checks" flag should reset.
-		future.resolve_without_forwarding(&network_graph, Err(UtxoLookupError::UnknownTx));
+		future.resolve(Err(UtxoLookupError::UnknownTx));
 		assert!(notifier.notify_pending());
+		network_graph.pending_checks.check_resolved_futures(&network_graph);
 		assert!(!network_graph.pending_checks.too_many_checks_pending());
 	}
 

--- a/lightning/src/util/test_utils.rs
+++ b/lightning/src/util/test_utils.rs
@@ -61,6 +61,7 @@ use crate::util::mut_global::MutGlobal;
 use crate::util::persist::{KVStore, KVStoreSync, MonitorName};
 use crate::util::ser::{Readable, ReadableArgs, Writeable, Writer};
 use crate::util::test_channel_signer::{EnforcementState, TestChannelSigner};
+use crate::util::wakers::Notifier;
 
 use bitcoin::amount::Amount;
 use bitcoin::block::Block;
@@ -2101,7 +2102,7 @@ impl TestChainSource {
 }
 
 impl UtxoLookup for TestChainSource {
-	fn get_utxo(&self, chain_hash: &ChainHash, _short_channel_id: u64) -> UtxoResult {
+	fn get_utxo(&self, chain_hash: &ChainHash, _scid: u64, _notifier: Arc<Notifier>) -> UtxoResult {
 		self.get_utxo_call_count.fetch_add(1, Ordering::Relaxed);
 		if self.chain_hash != *chain_hash {
 			return UtxoResult::Sync(Err(UtxoLookupError::UnknownChain));

--- a/pending_changelog/4213.txt
+++ b/pending_changelog/4213.txt
@@ -1,0 +1,5 @@
+Backwards compat
+================
+
+ * Outbound payments which are awaiting a response to a BOLT 12 invoice request
+   will not be able to complete after upgrading to 0.3 (#4213).


### PR DESCRIPTION
## Summary

- Add `payment_nonce: Option<Nonce>` field to `Event::PaymentSent` so downstream consumers (e.g. ldk-node) can construct payer proofs without intercepting `InvoiceReceived`
- Extract the nonce from `OffersContext::OutboundPaymentForOffer`/`OutboundPaymentForRefund` when the BOLT 12 invoice is received
- Thread the nonce through `HTLCSource::OutboundRoute`, `PendingOutboundPayment::Retryable`, and `SendAlongPathArgs` so it survives restarts and retries
- All new fields are serialized as optional TLVs for backwards compatibility

This removes the need for ldk-node to set `manually_handle_bolt12_invoices = true` and manually call `send_payment_for_bolt12_invoice` just to capture the nonce, as was done in https://github.com/lightningdevkit/ldk-node/pull/845.

## Test plan

- [x] `cargo check` passes
- [x] `cargo check --tests` passes
- [x] `outbound_payment::tests` (12/12 pass)
- [x] `ln::payment_tests` (51/51 pass)
- [x] `ln::offers_tests` (37/37 pass)
- [x] `ln::channelmanager::tests` (17/17 pass)
- [ ] Full CI


🤖 Generated with [Claude Code](https://claude.com/claude-code)