### PR TITLE
payer_proof: replace recursive DFS with iterative DFS

### DIFF
--- a/lightning/src/offers/merkle.rs
+++ b/lightning/src/offers/merkle.rs
@@ -421,98 +421,75 @@ fn compute_omitted_markers(tlv_data: &[TlvMerkleData]) -> Vec<u64> {
 	markers
 }
 
-/// A node in the merkle tree during selective disclosure processing.
-struct TreeNode {
-	hash: Option<sha256::Hash>,
-	included: bool,
-	min_type: u64,
+/// Task for iterative post-order DFS over the implicit merkle tree.
+enum DfsTask {
+	/// Descend into a subtree covering the range [start..start+len).
+	Descend { start: usize, len: usize },
+	/// Combine two child hashes after both subtrees have been processed.
+	Combine,
 }
 
-/// Build merkle tree and collect missing_hashes for omitted subtrees.
+/// Build merkle tree iteratively (DFS, left-to-right) and collect missing_hashes.
 ///
-/// Returns hashes sorted by ascending TLV type as required by the spec. For internal
-/// nodes, the type used for ordering is the minimum TLV type in that subtree.
+/// Per the spec, missing_hashes are in depth-first left-to-right order.
+/// Uses an explicit stack to simulate post-order DFS without recursion.
 ///
-/// Uses `n` tree nodes (one per TLV) rather than `2n`, since the per-TLV hashes
-/// already combine leaf and nonce. The tree traversal starts at level 0 to pair
-/// adjacent per-TLV hashes, matching the structure of `root_hash()`.
+/// Note: a level-by-level approach (as used by `root_hash()`) cannot produce
+/// DFS-ordered missing_hashes because it processes all subtrees at each depth
+/// simultaneously rather than completing each subtree before the next.
 fn build_tree_with_disclosure(
 	tlv_data: &[TlvMerkleData], branch_tag: &sha256::HashEngine,
 ) -> (sha256::Hash, Vec<sha256::Hash>) {
-	let num_nodes = tlv_data.len();
-	debug_assert!(num_nodes > 0, "TLV stream must contain at least one record");
+	debug_assert!(!tlv_data.is_empty(), "TLV stream must contain at least one record");
 
-	let num_omitted = tlv_data.iter().filter(|d| !d.is_included).count();
+	let mut missing_hashes = Vec::new();
+	// Each entry: (hash, has_included_leaf_in_subtree)
+	let mut hash_stack: Vec<(sha256::Hash, bool)> = Vec::new();
+	let mut task_stack: Vec<DfsTask> = vec![DfsTask::Descend { start: 0, len: tlv_data.len() }];
 
-	let mut nodes: Vec<TreeNode> = tlv_data
-		.iter()
-		.map(|data| TreeNode {
-			hash: Some(data.per_tlv_hash),
-			included: data.is_included,
-			min_type: data.tlv_type,
-		})
-		.collect();
+	while let Some(task) = task_stack.pop() {
+		match task {
+			DfsTask::Descend { start, len } => {
+				if len == 1 {
+					hash_stack.push((tlv_data[start].per_tlv_hash, tlv_data[start].is_included));
+				} else {
+					let mid = len.next_power_of_two() / 2;
+					// Push combine first (processed after both children).
+					task_stack.push(DfsTask::Combine);
+					// Push right then left so left is processed first (LIFO).
+					task_stack.push(DfsTask::Descend { start: start + mid, len: len - mid });
+					task_stack.push(DfsTask::Descend { start, len: mid });
+				}
+			},
+			DfsTask::Combine => {
+				let (right_hash, right_incl) = hash_stack.pop().unwrap();
+				let (left_hash, left_incl) = hash_stack.pop().unwrap();
 
-	let mut missing_with_types: Vec<(u64, sha256::Hash)> = Vec::with_capacity(num_omitted);
+				if left_incl && !right_incl {
+					missing_hashes.push(right_hash);
+				} else if !left_incl && right_incl {
+					missing_hashes.push(left_hash);
+				}
 
-	for level in 0.. {
-		let step = 2 << level;
-		let offset = step / 2;
-		if offset >= num_nodes {
-			break;
-		}
-
-		for (left_pos, right_pos) in
-			(0..num_nodes).step_by(step).zip((offset..num_nodes).step_by(step))
-		{
-			let left_hash = nodes[left_pos].hash;
-			let right_hash = nodes[right_pos].hash;
-			let left_incl = nodes[left_pos].included;
-			let right_incl = nodes[right_pos].included;
-			let right_min_type = nodes[right_pos].min_type;
-
-			match (left_hash, right_hash) {
-				(Some(l), Some(r)) => {
-					if left_incl != right_incl {
-						let (missing_type, missing_hash) = if right_incl {
-							(nodes[left_pos].min_type, l)
-						} else {
-							(right_min_type, r)
-						};
-						missing_with_types.push((missing_type, missing_hash));
-					}
-					nodes[left_pos].hash =
-						Some(tagged_branch_hash_from_engine(branch_tag.clone(), l, r));
-					nodes[left_pos].included |= left_incl || right_incl;
-					nodes[left_pos].min_type =
-						core::cmp::min(nodes[left_pos].min_type, right_min_type);
-				},
-				(Some(_), None) => {},
-				_ => unreachable!("Invalid state in merkle tree construction"),
-			}
+				let combined =
+					tagged_branch_hash_from_engine(branch_tag.clone(), left_hash, right_hash);
+				hash_stack.push((combined, left_incl || right_incl));
+			},
 		}
 	}
 
-	missing_with_types.sort_by_key(|(min_type, _)| *min_type);
-	let missing_hashes: Vec<sha256::Hash> =
-		missing_with_types.into_iter().map(|(_, h)| h).collect();
-
-	(nodes[0].hash.expect("Tree should have a root"), missing_hashes)
+	let (root, _) = hash_stack.pop().unwrap();
+	(root, missing_hashes)
 }
 
 /// Reconstruct merkle root from selective disclosure data.
 ///
-/// The `missing_hashes` must be in ascending type order per spec.
-///
-/// Uses `n` tree nodes (one per TLV position) rather than `2n`, since per-TLV
-/// hashes already combine leaf and nonce. Two passes over the tree determine
-/// where missing hashes are needed and then combine all hashes to the root.
+/// `missing_hashes` must be in DFS (left-to-right recursive traversal) order,
+/// matching the order produced by [`build_tree_with_disclosure`].
 pub(super) fn reconstruct_merkle_root<'a>(
 	included_records: &[(u64, &'a [u8])], leaf_hashes: &[sha256::Hash], omitted_markers: &[u64],
 	missing_hashes: &[sha256::Hash],
 ) -> Result<sha256::Hash, SelectiveDisclosureError> {
-	// Callers are expected to validate omitted_markers before calling this function
-	// (e.g., via validate_omitted_markers_for_parsing). Debug-assert for safety.
 	debug_assert!(validate_omitted_markers(omitted_markers).is_ok());
 
 	if included_records.len() != leaf_hashes.len() {
@@ -522,135 +499,118 @@ pub(super) fn reconstruct_merkle_root<'a>(
 	let leaf_tag = tagged_hash_engine(sha256::Hash::hash("LnLeaf".as_bytes()));
 	let branch_tag = tagged_hash_engine(sha256::Hash::hash("LnBranch".as_bytes()));
 
-	// Build TreeNode vec directly by interleaving included/omitted positions,
-	// eliminating the intermediate Vec<bool> from reconstruct_positions_from_records.
+	// Build per-position hash array: Some(hash) for included positions, None for omitted.
+	// TLV0 is always at position 0 (implicitly omitted).
 	let num_nodes = 1 + included_records.len() + omitted_markers.len();
-	let mut nodes: Vec<TreeNode> = Vec::with_capacity(num_nodes);
-
-	// TLV0 is always omitted
-	nodes.push(TreeNode { hash: None, included: false, min_type: 0 });
+	let mut hashes: Vec<Option<sha256::Hash>> = Vec::with_capacity(num_nodes);
+	hashes.push(None); // TLV0 always omitted
 
 	let mut inc_idx = 0;
 	let mut mrk_idx = 0;
 	let mut prev_marker: u64 = 0;
-	let mut node_idx: u64 = 1;
 
 	while inc_idx < included_records.len() || mrk_idx < omitted_markers.len() {
 		if mrk_idx >= omitted_markers.len() {
-			// No more markers, remaining positions are included
 			let (_, record_bytes) = included_records[inc_idx];
 			let leaf_hash = tagged_hash_from_engine(leaf_tag.clone(), record_bytes);
 			let nonce_hash = leaf_hashes[inc_idx];
-			let hash = tagged_branch_hash_from_engine(branch_tag.clone(), leaf_hash, nonce_hash);
-			nodes.push(TreeNode { hash: Some(hash), included: true, min_type: node_idx });
+			hashes.push(Some(tagged_branch_hash_from_engine(
+				branch_tag.clone(),
+				leaf_hash,
+				nonce_hash,
+			)));
 			inc_idx += 1;
 		} else if inc_idx >= included_records.len() {
-			// No more included types, remaining positions are omitted
-			nodes.push(TreeNode { hash: None, included: false, min_type: node_idx });
+			hashes.push(None);
 			prev_marker = omitted_markers[mrk_idx];
 			mrk_idx += 1;
 		} else {
 			let marker = omitted_markers[mrk_idx];
 			let (inc_type, _) = included_records[inc_idx];
-
 			if marker == prev_marker + 1 {
-				// Continuation of current run -> omitted position
-				nodes.push(TreeNode { hash: None, included: false, min_type: node_idx });
+				hashes.push(None);
 				prev_marker = marker;
 				mrk_idx += 1;
 			} else {
-				// Jump detected -> included position comes first
 				let (_, record_bytes) = included_records[inc_idx];
 				let leaf_hash = tagged_hash_from_engine(leaf_tag.clone(), record_bytes);
 				let nonce_hash = leaf_hashes[inc_idx];
-				let hash =
-					tagged_branch_hash_from_engine(branch_tag.clone(), leaf_hash, nonce_hash);
-				nodes.push(TreeNode { hash: Some(hash), included: true, min_type: node_idx });
+				hashes.push(Some(tagged_branch_hash_from_engine(
+					branch_tag.clone(),
+					leaf_hash,
+					nonce_hash,
+				)));
 				prev_marker = inc_type;
 				inc_idx += 1;
 			}
 		}
-		node_idx += 1;
 	}
 
-	// First pass: walk the tree to discover which positions need missing hashes.
-	// We mutate nodes[].included and nodes[].min_type directly since the second
-	// pass only reads nodes[].hash, making this safe without a separate allocation.
-	let num_omitted = omitted_markers.len() + 1; // +1 for implicit TLV0
-	let mut needs_hash: Vec<(u64, usize)> = Vec::with_capacity(num_omitted);
+	// Iterative DFS reconstruction: consume missing_hashes in DFS order.
+	// result_stack holds Option<hash>: Some = subtree has included leaves, None = all omitted.
+	let mut result_stack: Vec<Option<sha256::Hash>> = Vec::new();
+	let mut task_stack: Vec<DfsTask> = vec![DfsTask::Descend { start: 0, len: num_nodes }];
+	let mut missing_idx: usize = 0;
 
-	for level in 0.. {
-		let step = 2 << level;
-		let offset = step / 2;
-		if offset >= num_nodes {
-			break;
-		}
+	while let Some(task) = task_stack.pop() {
+		match task {
+			DfsTask::Descend { start, len } => {
+				if len == 1 {
+					result_stack.push(hashes[start]);
+				} else {
+					let mid = len.next_power_of_two() / 2;
+					task_stack.push(DfsTask::Combine);
+					task_stack.push(DfsTask::Descend { start: start + mid, len: len - mid });
+					task_stack.push(DfsTask::Descend { start, len: mid });
+				}
+			},
+			DfsTask::Combine => {
+				let right = result_stack.pop().unwrap();
+				let left = result_stack.pop().unwrap();
 
-		for left_pos in (0..num_nodes).step_by(step) {
-			let right_pos = left_pos + offset;
-			if right_pos >= num_nodes {
-				continue;
-			}
-
-			let r_min = nodes[right_pos].min_type;
-
-			match (nodes[left_pos].included, nodes[right_pos].included) {
-				(true, false) => {
-					needs_hash.push((r_min, right_pos));
-					nodes[left_pos].min_type = core::cmp::min(nodes[left_pos].min_type, r_min);
-				},
-				(false, true) => {
-					needs_hash.push((nodes[left_pos].min_type, left_pos));
-					nodes[left_pos].included = true;
-					nodes[left_pos].min_type = core::cmp::min(nodes[left_pos].min_type, r_min);
-				},
-				(true, true) => {
-					nodes[left_pos].min_type = core::cmp::min(nodes[left_pos].min_type, r_min);
-				},
-				(false, false) => {
-					nodes[left_pos].min_type = core::cmp::min(nodes[left_pos].min_type, r_min);
-				},
-			}
+				match (left, right) {
+					(None, None) => result_stack.push(None),
+					(Some(l), None) => {
+						if missing_idx >= missing_hashes.len() {
+							return Err(SelectiveDisclosureError::InsufficientMissingHashes);
+						}
+						let r = missing_hashes[missing_idx];
+						missing_idx += 1;
+						result_stack.push(Some(tagged_branch_hash_from_engine(
+							branch_tag.clone(),
+							l,
+							r,
+						)));
+					},
+					(None, Some(r)) => {
+						if missing_idx >= missing_hashes.len() {
+							return Err(SelectiveDisclosureError::InsufficientMissingHashes);
+						}
+						let l = missing_hashes[missing_idx];
+						missing_idx += 1;
+						result_stack.push(Some(tagged_branch_hash_from_engine(
+							branch_tag.clone(),
+							l,
+							r,
+						)));
+					},
+					(Some(l), Some(r)) => {
+						result_stack.push(Some(tagged_branch_hash_from_engine(
+							branch_tag.clone(),
+							l,
+							r,
+						)));
+					},
+				}
+			},
 		}
 	}
 
-	needs_hash.sort_by_key(|(min_pos, _)| *min_pos);
-
-	if needs_hash.len() != missing_hashes.len() {
+	if missing_idx != missing_hashes.len() {
 		return Err(SelectiveDisclosureError::InsufficientMissingHashes);
 	}
 
-	// Place missing hashes directly into the nodes array.
-	for (i, &(_, tree_pos)) in needs_hash.iter().enumerate() {
-		nodes[tree_pos].hash = Some(missing_hashes[i]);
-	}
-
-	// Second pass: combine hashes up the tree.
-	for level in 0.. {
-		let step = 2 << level;
-		let offset = step / 2;
-		if offset >= num_nodes {
-			break;
-		}
-
-		for left_pos in (0..num_nodes).step_by(step) {
-			let right_pos = left_pos + offset;
-			if right_pos >= num_nodes {
-				continue;
-			}
-
-			match (nodes[left_pos].hash, nodes[right_pos].hash) {
-				(Some(l), Some(r)) => {
-					nodes[left_pos].hash =
-						Some(tagged_branch_hash_from_engine(branch_tag.clone(), l, r));
-				},
-				(Some(_), None) => {},
-				(None, _) => {},
-			};
-		}
-	}
-
-	nodes[0].hash.ok_or(SelectiveDisclosureError::InsufficientMissingHashes)
+	result_stack.pop().unwrap().ok_or(SelectiveDisclosureError::InsufficientMissingHashes)
 }
 
 fn validate_omitted_markers(markers: &[u64]) -> Result<(), SelectiveDisclosureError> {

--- a/lightning/src/offers/payer_proof.rs
+++ b/lightning/src/offers/payer_proof.rs
@@ -1592,4 +1592,155 @@ mod tests {
 		assert_eq!(parsed.payment_hash(), payment_hash);
 		assert_eq!(parsed.payer_note().map(|note| note.to_string()), Some("refund".to_string()));
 	}
+
+	// BOLT 12 payer proof test vectors (from bolt12/payer-proof-test.json).
+	// All four vectors share the same invoice and preimage.
+	const PAYER_SECRET_HEX: &str = "4242424242424242424242424242424242424242424242424242424242424242";
+	const INVOICE_HEX: &str = "0010000000000000000000000000000000001621024bc2a31265153f07e70e0bab08724e6b85e217f8cd628ceb62974247bb493382520203e858210324653eac434488002cc06bbfb7f10fe18991e35f9fe4302dbea6d2353dc0ab1ca076027f31ebc5462c1fdce1b737ecff52d37d75dea43ce11c74d25aa297165faa2007032c0b7cf95324a07d05398b240174dc0c2be444d96b159aa6c7f7b1e6686809910102edabbd16b41c8371b92ef2f04c1185b4f03b6dcd52ba9b78d9d7c89c8f221145001000000000000000000000000000000000a21c00000001000000020003000000000000000400000000000000050000a40467527988a82072cd6e8422c407fb6d098690f1130b7ded7ec2f7f5e1d30bd9d521f015363793aa0203e8b021024bc2a31265153f07e70e0bab08724e6b85e217f8cd628ceb62974247bb493382f04098c093015fb630fa7aeeecebb7af826edc447244d4fab5d535fbf1ca008ff086bcb7d612f105d0aeeaf5711c30af20e8b438d736ca4d774af4cbdc7d855c8f88feb2d05e010142";
+	const PREIMAGE_HEX: &str = "0101010101010101010101010101010101010101010101010101010101010101";
+
+	struct PayerProofVector {
+		name: &'static str,
+		included_types: &'static [u64],
+		note: Option<&'static str>,
+		leaf_hashes_hex: &'static str,
+		omitted_tlvs: &'static [u64],
+		missing_hashes_hex: &'static str,
+		merkle_root_hex: &'static str,
+		bech32: &'static str,
+	}
+
+	const PAYER_PROOF_VECTORS: &[PayerProofVector] = &[
+		PayerProofVector {
+			name: "full_disclosure",
+			included_types: &[22, 82, 160, 162, 164, 170, 3000000001],
+			note: None,
+			leaf_hashes_hex: "8c9057ed88f3c5a6b6441dcac3b5e4cefb3615904d7362b86e78427fb695f4618dc54a97453dee6f207fa5216a30f1567442712ca98852bc789b73885029283cf2deaf5f30be3ced89fc7c24d422819bf06af0e48a31423bbd0e2634f3c3de67f54f80c94a87383f2a8ef7c3e461c62b67a51da5bccf6cd96a7dbab29bea51fa7849b8b856e1d2a63d9ce7dc1a78e05cbb2def1f5d7709c48e8707e0a59fe51e19e7e4eee6bf56c6c589fe50035490c1a7c91b753cb8007c4b52838a6772f997f0191c35000247554b8d0a196898a794bf3de89982571178d931affb654f0c1adc0b8de03f1a0b0531bff146982d7d613ef6e1ef8d3bdd9590971fc18d835ffb7e92b77b9e3843650f6cd7ee94b6753ea9df3533710b04dee686ad376515a5cbabaab91b367e30fea7026daf9f2590bb7e9cc31db8221f4013c67289e38f22c8",
+			omitted_tlvs: &[],
+			missing_hashes_hex: "0b510ba4c6884d603159ced2f0ca21e772424b59e52a2191bbfbcf07377805a1",
+			merkle_root_hex: "d75cc1c4a81b39f841f8db4e8b3156f73d973f32fc982cdce884f2d396504db1",
+			bech32: "lnp1zcssyj7z5vfx29flqlnsuzatppeyu6u9ugtl3ntz3n4k996zg7a5jvuz2gpq86zcyypjgef743p5fzqq9nqxh0ah7y87rzv3ud0eleps9kl2d5348hq2k89qwcp87v0tc4rzc87uuxmn0m8l2tfh6aw75s7wz8r56fd299ckt74zqpcr9s9he72nyjs86pfe3vjqzaxups47g3xedv2e4fk877c7v6rgpxgszqhd4w73ddqusdcmjthj7pxprpd57qakmn2jh2dh3kwhezwg7gs3g5qpqqqqqqqqqqqqqqqqqqqqqqqqqq9zrsqqqqqpqqqqqqsqqvqqqqqqqqqqqpqqqqqqqqqqqqzsqq9yq3n4y7vg4qs89ntwss3vgplmd5ycdy83zv9hmmt7ctmltcwnp0va2g0sz5mr0ya2qgp73vppqf9u9gcjv52n7pl8pc96kzrjfe4ctcshlrxk9r8tv2t5y3amfyec9uzqnrqfxq2lkcc057hwan4m0tuzdmwygujy6natt4f4l0cu5qy07zrted7kztcst59wat6hz8ps4usw3dpc6umv5nthft6vhhras4wglz8jyqqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqsra3qpdgshfxx3pxkqv2eemf0pj3puaeyyj6eu54zrydml08swdmcqksl3lgpgzxfq4ld3reutf4kgswu4sa4un80kds4jpxhxc4cdeuyylakjh6xrrw9f2t5200wdus8lffpdgc0z4n5gfcje2vg22783xmn3pgzj2pu7t027heshc7wmz0u0sjdgg5pn0cx4u8y3gc5ywaapcnrfu7rmenl2nuqe99gwwpl92800slyv8rzkea9rkjmenmvm948mw4jn049r7ncfxuts4hp62nrm888msd83czuhvk7786awuyufr58qls2t8l9rcv70e8wu6l4d3k938l9qq65jrq60jgmw57tsqrufdfg8zn8wtue0uqers6sqqj8249c6zsedzv2099l8h5fnqjhz9udjvd0ldj57rq6ms9cmcplrg9s2vdl79rfsttavyl0dc0035aam9vsju0urrvrtlahay4h0w0rssm9pakd0m55ke6na2wlx5ehzzcymmngdtfhv526tjat42u3kdn7xrl2wqnd470jty9m06wvx8dcyg05qy7xw2y78rezerayq3hqtyn5aat00khnft954rp9e9xe5rcjwujcf9haa46ngfrszv8pctgspa890llf6qh0emq2gr2lv87ta6ly7vrnk583tcaj0kvv33p0avkstcqszss",
+		},
+		PayerProofVector {
+			name: "minimal_disclosure",
+			included_types: &[],
+			note: None,
+			leaf_hashes_hex: "f2deaf5f30be3ced89fc7c24d422819bf06af0e48a31423bbd0e2634f3c3de67f0191c35000247554b8d0a196898a794bf3de89982571178d931affb654f0c1a7e92b77b9e3843650f6cd7ee94b6753ea9df3533710b04dee686ad376515a5cb",
+			omitted_tlvs: &[1, 2, 89, 90, 91, 169, 177],
+			missing_hashes_hex: "bf8cb2b1d6fa9bcdcab501b59f82c65c506b7f43514737f7197f1fcfeaebad41b9406f4ce526a6a0d4e0b3a63ed89a832e31cb9939dfe1a7b5dd7232d32c02abcd9c44b53b31700c9ed0e3330ce425f7f18fac2fc1d566a34468439274f0e3169f9830f2c3070cfbad13fde30ee36cd7143591164ed12040a9cd595c96840ac9998ab7fa9c743fb9dbdb0d8d46fbe3ad333400bd07f328dcdb6008790bc9d2db3358d8be254efbc28a1f7f9caa8c21432ba93b512d07349764d61386f186471a",
+			merkle_root_hex: "d75cc1c4a81b39f841f8db4e8b3156f73d973f32fc982cdce884f2d396504db1",
+			bech32: "lnp1tqssxfr986kyx3ygqqkvq6alklcslcvfj834l8lyxqkmafkjx57up2cu4qs89ntwss3vgplmd5ycdy83zv9hmmt7ctmltcwnp0va2g0sz5mr0yasyypyhs4rzfj320c8uu8qh2cgwf8xhp0zzluv6c5vad3fwsj8hdyn8qhsgzvvpycpt7mrp7n6amkwhda0sfhdc3rjgn204dw4xhalrjsq3lcgd09h6cf0zpws4m402uguxzhjp6958rtndjjdwa90fj7u0kz4erug7gsqzqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszq05quqsyk26tw5mrakqh7xt9vwkl2dumj44qx6elqkxt3gxkl6r29rn0ace0u0ul6ht44qmjsr0fnjjdf4q6nst8f37mzdgxt33ewvnnhlp576a6u3j6vkq927dn3zt2we3wqxfa58rxvxwgf0h7x86ct7p64n2x3rggwf8fu8rz60esv8jcvrse7adz077xrhrdnt3gdv3ze8dzgzq48x4jhykss9vnxv2klafcaplh8dakrvdgma78tfnxsqt6pln9rwdkcqg0y9un5kmxdvd3039fmau9zsl07w24rppgv46jw6395rnf9my6cfcduvxgud0sc8jm6h47v978nkcnlruyn2z9qvm7p40pey2x9prh0gwyc608s77vlcpj8p4qqpyw42t359pj6yc572t700gnxp9wytcmyc6l7m9fuxp5l5jkaaeuwzrv58ke4lwjjm8204fmu6nxugtqn0wdp4dxaj3tfwtlfqydczeya802mma4u62ed9gcfwffkdq7ynhykzfdl0dw56zguqnpcwz6yq0fetll6ws9m7wczjq6hmpljlwhe8nqua4pu278vnanryvgg",
+		},
+		PayerProofVector {
+			name: "with_note",
+			included_types: &[],
+			note: Some("test note"),
+			leaf_hashes_hex: "f2deaf5f30be3ced89fc7c24d422819bf06af0e48a31423bbd0e2634f3c3de67f0191c35000247554b8d0a196898a794bf3de89982571178d931affb654f0c1a7e92b77b9e3843650f6cd7ee94b6753ea9df3533710b04dee686ad376515a5cb",
+			omitted_tlvs: &[1, 2, 89, 90, 91, 169, 177],
+			missing_hashes_hex: "bf8cb2b1d6fa9bcdcab501b59f82c65c506b7f43514737f7197f1fcfeaebad41b9406f4ce526a6a0d4e0b3a63ed89a832e31cb9939dfe1a7b5dd7232d32c02abcd9c44b53b31700c9ed0e3330ce425f7f18fac2fc1d566a34468439274f0e3169f9830f2c3070cfbad13fde30ee36cd7143591164ed12040a9cd595c96840ac9998ab7fa9c743fb9dbdb0d8d46fbe3ad333400bd07f328dcdb6008790bc9d2db3358d8be254efbc28a1f7f9caa8c21432ba93b512d07349764d61386f186471a",
+			merkle_root_hex: "d75cc1c4a81b39f841f8db4e8b3156f73d973f32fc982cdce884f2d396504db1",
+			bech32: "lnp1tqssxfr986kyx3ygqqkvq6alklcslcvfj834l8lyxqkmafkjx57up2cu4qs89ntwss3vgplmd5ycdy83zv9hmmt7ctmltcwnp0va2g0sz5mr0yasyypyhs4rzfj320c8uu8qh2cgwf8xhp0zzluv6c5vad3fwsj8hdyn8qhsgzvvpycpt7mrp7n6amkwhda0sfhdc3rjgn204dw4xhalrjsq3lcgd09h6cf0zpws4m402uguxzhjp6958rtndjjdwa90fj7u0kz4erug7gsqzqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszq05quqsyk26tw5mrakqh7xt9vwkl2dumj44qx6elqkxt3gxkl6r29rn0ace0u0ul6ht44qmjsr0fnjjdf4q6nst8f37mzdgxt33ewvnnhlp576a6u3j6vkq927dn3zt2we3wqxfa58rxvxwgf0h7x86ct7p64n2x3rggwf8fu8rz60esv8jcvrse7adz077xrhrdnt3gdv3ze8dzgzq48x4jhykss9vnxv2klafcaplh8dakrvdgma78tfnxsqt6pln9rwdkcqg0y9un5kmxdvd3039fmau9zsl07w24rppgv46jw6395rnf9my6cfcduvxgud0sc8jm6h47v978nkcnlruyn2z9qvm7p40pey2x9prh0gwyc608s77vlcpj8p4qqpyw42t359pj6yc572t700gnxp9wytcmyc6l7m9fuxp5l5jkaaeuwzrv58ke4lwjjm8204fmu6nxugtqn0wdp4dxaj3tfwtlfyuphgt5cgcrfg50lvxftvudtmrf7ns44kal2njhfqqqy23vh0v0vn4uv74dv966eq8gmsx3xkgt3nmq6f0kzztcj9xqfcs80g6aj6sde6x2um5yphx7ar9",
+		},
+		PayerProofVector {
+			name: "left_subtree_omitted",
+			included_types: &[170],
+			note: None,
+			leaf_hashes_hex: "f2deaf5f30be3ced89fc7c24d422819bf06af0e48a31423bbd0e2634f3c3de67f0191c35000247554b8d0a196898a794bf3de89982571178d931affb654f0c1adc0b8de03f1a0b0531bff146982d7d613ef6e1ef8d3bdd9590971fc18d835ffb7e92b77b9e3843650f6cd7ee94b6753ea9df3533710b04dee686ad376515a5cb",
+			omitted_tlvs: &[1, 2, 89, 90, 91, 177],
+			missing_hashes_hex: "bf8cb2b1d6fa9bcdcab501b59f82c65c506b7f43514737f7197f1fcfeaebad41b9406f4ce526a6a0d4e0b3a63ed89a832e31cb9939dfe1a7b5dd7232d32c02abcd9c44b53b31700c9ed0e3330ce425f7f18fac2fc1d566a34468439274f0e3169f9830f2c3070cfbad13fde30ee36cd7143591164ed12040a9cd595c96840ac93358d8be254efbc28a1f7f9caa8c21432ba93b512d07349764d61386f186471a",
+			merkle_root_hex: "d75cc1c4a81b39f841f8db4e8b3156f73d973f32fc982cdce884f2d396504db1",
+			bech32: "lnp1tqssxfr986kyx3ygqqkvq6alklcslcvfj834l8lyxqkmafkjx57up2cu4qs89ntwss3vgplmd5ycdy83zv9hmmt7ctmltcwnp0va2g0sz5mr0ya2qgp73vppqf9u9gcjv52n7pl8pc96kzrjfe4ctcshlrxk9r8tv2t5y3amfyec9uzqnrqfxq2lkcc057hwan4m0tuzdmwygujy6natt4f4l0cu5qy07zrted7kztcst59wat6hz8ps4usw3dpc6umv5nthft6vhhras4wglz8jyqqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqsraqxqyp9jkjmk8m2p0uvk2cad75meh9t2qd4n7pvvhzsddl5x528xlm3jlclel4wht2ph9qx7n89y6n2p48qkwnraky6svhrrjue8807rfa4m4er95evq24um8zyk5anzuqvnmgwxvcvusjl0uv04shur4tx5dzxssujwncwx95lnqc09sc8pna66ylauv8wxmxhzs6ez9jw6ysyp2wdt9wfdpq2eye43k97y480hs52ralee25vy9pjh2fm2ykswdyhvntp8ph3ser347yq7t027heshc7wmz0u0sjdgg5pn0cx4u8y3gc5ywaapcnrfu7rmenlqxgux5qqy364fwxs5xtgnznef0eaazvcy4c30rvnrtlmv48scxkupwx7q0c6pvznr0l3g6vz6ltp8mmwrmud80wetyyhrlqcmq6lldlf9dmmncuyxeg0dnt7a99kw5l2nhe4xdcskpx7u6r26dm9zkjuh7jqgms9jf6w74hhmte54j623sjujnv6puf8wfvyjm776af5y3cpxrsu95gq7njhll5aqthuas9yp40krl97a0j0xpem2rc4uwe8mxxgcss",
+		},
+	];
+
+	fn hex_decode(s: &str) -> Vec<u8> {
+		(0..s.len()).step_by(2).map(|i| u8::from_str_radix(&s[i..i + 2], 16).unwrap()).collect()
+	}
+
+	fn hex_encode(b: &[u8]) -> String {
+		b.iter().map(|x| format!("{:02x}", x)).collect()
+	}
+
+	/// Split a concatenated hex string into 32-byte hash hex strings.
+	fn split_hashes_hex(hex: &str) -> Vec<String> {
+		(0..hex.len()).step_by(64).map(|i| hex[i..i + 64].to_string()).collect()
+	}
+
+	#[test]
+	fn check_against_spec_vectors() {
+		let secp_ctx = Secp256k1::new();
+		let payer_keys = Keypair::from_secret_key(
+			&secp_ctx,
+			&SecretKey::from_slice(&hex_decode(PAYER_SECRET_HEX)).unwrap(),
+		);
+
+		let invoice = Bolt12Invoice::try_from(hex_decode(INVOICE_HEX))
+			.expect("failed to parse invoice from test vector");
+
+		let preimage = PaymentPreimage(hex_decode(PREIMAGE_HEX).try_into().unwrap());
+
+		for vector in PAYER_PROOF_VECTORS {
+			let mut builder = PayerProofBuilder::new(&invoice, preimage)
+				.unwrap_or_else(|e| panic!("{}: builder failed: {:?}", vector.name, e));
+			for &typ in vector.included_types {
+				if typ != INVOICE_REQUEST_PAYER_ID_TYPE
+					&& typ != INVOICE_PAYMENT_HASH_TYPE
+					&& typ != INVOICE_NODE_ID_TYPE
+				{
+					builder = builder.include_type(typ).unwrap_or_else(|e| {
+						panic!("{}: include_type({}) failed: {:?}", vector.name, typ, e)
+					});
+				}
+			}
+
+			let unsigned = builder
+				.build_unsigned()
+				.unwrap_or_else(|e| panic!("{}: build failed: {:?}", vector.name, e));
+
+			let got_leaves: Vec<String> =
+				unsigned.disclosure.leaf_hashes.iter().map(|h| hex_encode(h.as_ref())).collect();
+			assert_eq!(
+				got_leaves,
+				split_hashes_hex(vector.leaf_hashes_hex),
+				"{}: leaf_hashes mismatch",
+				vector.name
+			);
+
+			assert_eq!(
+				unsigned.disclosure.omitted_markers, vector.omitted_tlvs,
+				"{}: omitted_tlvs mismatch",
+				vector.name
+			);
+
+			let got_missing: Vec<String> = unsigned
+				.disclosure
+				.missing_hashes
+				.iter()
+				.map(|h| hex_encode(h.as_ref()))
+				.collect();
+			assert_eq!(
+				got_missing,
+				split_hashes_hex(vector.missing_hashes_hex),
+				"{}: missing_hashes mismatch",
+				vector.name
+			);
+
+			let got_root = hex_encode(unsigned.disclosure.merkle_root.as_ref());
+			assert_eq!(got_root, vector.merkle_root_hex, "{}: merkle_root mismatch", vector.name);
+
+			let proof = unsigned
+				.sign(
+					|message| Ok(secp_ctx.sign_schnorr_no_aux_rand(message, &payer_keys)),
+					vector.note,
+				)
+				.unwrap_or_else(|e| panic!("{}: sign failed: {:?}", vector.name, e));
+
+			assert_eq!(
+				proof.to_string(),
+				vector.bech32,
+				"{}: bech32 mismatch",
+				vector.name
+			);
+		}
+	}
 }


### PR DESCRIPTION
## Summary
- Replaces recursive `build_tree_dfs` / `reconstruct_dfs` with iterative post-order DFS using an explicit `DfsTask` stack
- Matches the iterative style used by `root_hash()` and the rest of the merkle code in the offers module
- Same DFS post-order semantics — `missing_hashes` ordering is identical

Fixup for #84 (commit 3b7742671).

## Test plan
- [x] All 44 merkle + payer_proof tests pass
- [x] `check_against_c_vectors` passes against C test vectors

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>